### PR TITLE
Multiple inserts per #42. does not handle cardinality

### DIFF
--- a/src/Commands/Languages/OrientSQL/CommandProcessor.php
+++ b/src/Commands/Languages/OrientSQL/CommandProcessor.php
@@ -82,7 +82,7 @@ class CommandProcessor implements ProcessorInterface
         $this->appendTarget("");
 
         /* CONTENT {} */
-        $this->appendData("CONTENT");
+        $this->appendInsertData();
         $this->addToScript("RETURN @this");
     }
 
@@ -127,7 +127,7 @@ class CommandProcessor implements ProcessorInterface
         $this->appendTarget("");
 
         /* MERGE {} */
-        $this->appendData("MERGE");
+        $this->appendUpdateData();
 
         /* WHERE */
         $this->appendWheres();
@@ -322,13 +322,74 @@ class CommandProcessor implements ProcessorInterface
     }
 
     /**
-     * Append data to current script
+     * Append insert data to current script
      * @param string $prefix
      * @throws \Exception
      */
-    protected function appendData($prefix = "content")
+    protected function appendInsertData($prefix = "content")
     {
-        $this->addToScript(strtoupper($prefix));
+        $keys = [];
+        $values = [];
+
+        /* Is this a multiple creation? */
+        /* ToDo: Way to many loops here */
+        if (isset($this->bag->data[0])) {
+            // First, we setup the keys array [key1, key2, key3]
+            foreach ($this->bag->data as $record) {
+                $keys = array_unique(array_merge($keys, array_keys($record)));
+            }
+
+            // Now we setup sets of values arrays ['one', null, 'two'], [null, 'three', 'four']
+            $i = 0;
+
+            // For every record
+            foreach ($this->bag->data as $record) {
+                // We check every key
+                $set = [];
+                foreach ($keys as $key) {
+                    // And set it to a value
+                    if (array_key_exists($key, $record)) {
+                        $set[] = $this->castValue($record[$key]);
+
+                    // Or to 'null'
+                    } else {
+                        $set[] = 'null';
+                    }
+                }
+
+                // Create the string for that value set
+                $values[$i] = '(' . implode(", ", $set) . ')';
+                $i++;
+            }
+
+        /* No, its a single creation */
+        } else {
+            $keys = array_keys($this->bag->data);
+            $values = array_values($this->bag->data);
+
+            $values = array_map(function ($value) {
+                return $this->castValue($value);
+            }, $values);
+        }
+
+        $stringValues = '(' . implode(", ", $values) . ')';
+        $stringValues = str_replace("((", "(", $stringValues);
+        $stringValues = str_replace("))", ")", $stringValues);
+
+        $stringKeys = implode(", ", $keys);
+
+        $data = "($stringKeys) VALUES $stringValues";
+        $this->addToScript($data);
+    }
+
+    /**
+     * Append update data to current script
+     * @param string $prefix
+     * @throws \Exception
+     */
+    protected function appendUpdateData($prefix = "content")
+    {
+        $this->addToScript("MERGE");
         $this->addToScript(json_encode($this->bag->data));
     }
 

--- a/tests/Unit/Commands/Languages/BaseTestSuite.php
+++ b/tests/Unit/Commands/Languages/BaseTestSuite.php
@@ -31,6 +31,36 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $actual = $this->processor()->process($bag);
             $this->assertEquals($expected, $actual, 'failed to return expected Command for simple select bag');
         });
+
+        $this->specify("it processes a multiple insert bag", function () {
+            $bag = new Bag();
+            $bag->command = Bag::COMMAND_CREATE;
+            $bag->target = 'target';
+
+            /* ToDo: data is too rigid. See note in BaseTest */
+            $bag->data = [
+                [
+                    'name' => 'mal',
+                    'role' => 'captain',
+                    'ship' => 'firefly'
+                ],
+                [
+                    'name' => 'zoe',
+                    'role' => 'first',
+                    'husband' => 'wash'
+                ],
+                [
+                    'name' => 'book',
+                    'role' => 'shepherd',
+                    'past' => 'unknown'
+                ]
+            ];
+
+            $expected = $this->getExpectedCommand('insert-multiple');
+
+            $actual = $this->processor()->process($bag);
+            $this->assertEquals($expected, $actual, 'failed to return expected Command for simple select bag');
+        });
     }
 
 

--- a/tests/Unit/Commands/Languages/OrientSqlProcessorTest.php
+++ b/tests/Unit/Commands/Languages/OrientSqlProcessorTest.php
@@ -20,8 +20,34 @@ class OrientSqlProcessorTest extends BaseTestSuite
     public function insertSimple()
     {
         $query = 'INSERT INTO target';
-        $query .= ' CONTENT ' . json_encode($this->getData());
+
+        /* ToDo: insert data should be produced dynamically */
+        /* In order to produce this on the fly, we had to copy processor methods */
+        /* This seemed to defeat the purpose of testing those methods */
+        $query .= " (one, two, three) VALUES (1, 'two', false)";
+
         $query .= ' RETURN @this';
+
+        $command = new Command($query);
+        $command->setScriptLanguage('OrientSQL');
+        $expected = $command;
+
+        return $expected;
+    }
+
+    /**
+     * Returns a command for the the Bag tested in
+     * testInsert:it processes a simple insert bag
+     */
+    public function insertMultiple()
+    {
+        $query = "INSERT INTO target ";
+        $query .= "(name, role, ship, husband, past)";
+        $query .= " VALUES ";
+        $query .= "('mal', 'captain', 'firefly', null, null), ";
+        $query .= "('zoe', 'first', null, 'wash', null), ";
+        $query .= "('book', 'shepherd', null, null, 'unknown')";
+        $query .= " RETURN @this";
 
         $command = new Command($query);
         $command->setScriptLanguage('OrientSQL');


### PR DESCRIPTION
See issue #42 

This now allows for (in the orient processor):

``` php
$builder->insert([
                [
                    'name' => 'mal',
                    'role' => 'captain',
                    'ship' => 'firefly'
                ],
                [
                    'name' => 'zoe',
                    'role' => 'first',
                    'husband' => 'wash'
                ],
                [
                    'name' => 'book',
                    'role' => 'shepherd',
                    'past' => 'unknown'
                ]
            ])->into('target);
```

It does not handle cardinality, but I like the DTO idea, generally.
