### PR TITLE
made multiple changes to how queries and drivers interract

### DIFF
--- a/src/Commands/BaseBuilder.php
+++ b/src/Commands/BaseBuilder.php
@@ -2,6 +2,7 @@
 namespace Spider\Commands;
 
 use InvalidArgumentException;
+use Spider\Commands\Languages\ProcessorInterface;
 
 /**
  * Fluent Command Builder, simple bag manipulation
@@ -282,7 +283,7 @@ class BaseBuilder
      * Return the current Command Bag
      * @return Bag
      */
-    public function getCommandBag()
+    public function getBag()
     {
         return $this->bag;
     }
@@ -341,12 +342,38 @@ class BaseBuilder
     }
 
     /**
-     * Read only of the Bag if required
-     *
-     * @return Bad the root Bag object for this builder
+     * Processes the current command bag
+     * @param ProcessorInterface $processor
+     * @return String the script in string form
+     * @throws \Exception
      */
-    public function getBag()
+    public function getScript(ProcessorInterface $processor = null)
     {
-        return $this->bag;
+        return $this->getCommand($processor)->getScript();
+    }
+
+    /**
+     * Processes the current command bag
+     * @param ProcessorInterface $processor
+     * @return Command
+     * @throws \Exception
+     */
+    public function getCommand(ProcessorInterface $processor = null)
+    {
+        if ($processor) {
+            $this->setProcessor($processor);
+        } else {
+            if (!$this->hasProcessor()) {
+                throw new \Exception(
+                    "`Builder` requires a valid instance of Spider\\Languages\\ProcessorInterface to build scripts"
+                );
+            }
+        }
+
+        $this->script = $this->processor->process(
+            $this->getBag()
+        );
+
+        return $this->script;
     }
 }

--- a/src/Commands/Builder.php
+++ b/src/Commands/Builder.php
@@ -229,29 +229,4 @@ class Builder extends BaseBuilder
     {
         return isset($this->processor) && $this->processor instanceof ProcessorInterface;
     }
-
-    /**
-     * Processes the current command bag
-     * @param ProcessorInterface $processor
-     * @return Command
-     * @throws \Exception
-     */
-    public function getScript(ProcessorInterface $processor = null)
-    {
-        if ($processor) {
-            $this->setProcessor($processor);
-        } else {
-            if (!$this->hasProcessor()) {
-                throw new \Exception(
-                    "`Builder` requires a valid instance of Spider\\Languages\\ProcessorInterface to build scripts"
-                );
-            }
-        }
-
-        $this->script = $this->processor->process(
-            $this->getCommandBag()
-        );
-
-        return $this->script;
-    }
 }

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -28,11 +28,10 @@ class Command implements CommandInterface
      * @param null $language
      * @param string $rw
      */
-    public function __construct($script = '', $language = null, $rw = 'write')
+    public function __construct($script = '', $language = null)
     {
         $this->setScript($script);
         $this->setScriptLanguage($language);
-        $this->setRw($rw);
     }
 
     /**
@@ -71,24 +70,6 @@ class Command implements CommandInterface
     public function setScriptLanguage($language)
     {
         $this->language = $language;
-    }
-
-    /**
-     * Is this a 'read' or 'write' command
-     * @return string
-     */
-    public function getRw()
-    {
-        return $this->rw;
-    }
-
-    /**
-     * Set this as a 'read' or 'write' command
-     * @param string $rw
-     */
-    public function setRw($rw)
-    {
-        $this->rw = $rw;
     }
 
     /**

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -37,16 +37,4 @@ interface CommandInterface
      * @return $this
      */
     public function setScriptLanguage($language);
-
-    /**
-     * Is this a 'read' or 'write' command
-     * @return string
-     */
-    public function getRw();
-
-    /**
-     * Set this as a 'read' or 'write' command
-     * @param string $rw
-     */
-    public function setRw($rw);
 }

--- a/src/Commands/Languages/OrientSQL/CommandProcessor.php
+++ b/src/Commands/Languages/OrientSQL/CommandProcessor.php
@@ -66,9 +66,6 @@ class CommandProcessor implements ProcessorInterface
         $command = new Command($this->script);
         $command->setScriptLanguage('OrientSQL');
 
-        $rw = ($bag->command === Bag::COMMAND_RETRIEVE) ? 'read' : 'write';
-        $command->setRw($rw);
-
         return $command;
     }
 

--- a/src/Connections/Connection.php
+++ b/src/Connections/Connection.php
@@ -105,10 +105,10 @@ class Connection extends Collection implements ConnectionInterface
     /**
      * Passes to driver: executes a Query or read command
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return Response
      */
-    public function executeReadCommand(CommandInterface $query)
+    public function executeReadCommand($query)
     {
         return $this->driver->executeReadCommand($query);
     }
@@ -118,11 +118,11 @@ class Connection extends Collection implements ConnectionInterface
      *
      * These are the "CUD" in CRUD
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      * @return Response
      * @internal param CommandInterface $sendCommand
      */
-    public function executeWriteCommand(CommandInterface $command)
+    public function executeWriteCommand($command)
     {
         return $this->driver->executeWriteCommand($command);
     }
@@ -130,10 +130,10 @@ class Connection extends Collection implements ConnectionInterface
     /**
      * Passes to driver: executes a read command without waiting for a response
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return $this
      */
-    public function runReadCommand(CommandInterface $query)
+    public function runReadCommand($query)
     {
         return $this->driver->runReadCommand($query);
     }
@@ -141,10 +141,10 @@ class Connection extends Collection implements ConnectionInterface
     /**
      * Passes to driver: executes a write command without waiting for a response
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      * @return $this
      */
-    public function runWriteCommand(CommandInterface $command)
+    public function runWriteCommand($command)
     {
         return $this->driver->runWriteCommand($command);
     }

--- a/src/Connections/ConnectionInterface.php
+++ b/src/Connections/ConnectionInterface.php
@@ -44,34 +44,34 @@ interface ConnectionInterface extends DriverInterface
     /**
      * Passes to driver: executes a Query or read command
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return Response
      */
-    public function executeReadCommand(CommandInterface $query);
+    public function executeReadCommand($query);
 
     /**
      * Passes to driver: executes a write command
      *
      * These are the "CUD" in CRUD
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      * @return Response
      */
-    public function executeWriteCommand(CommandInterface $command);
+    public function executeWriteCommand($command);
 
     /**
      * Passes to driver: executes a read command without waiting for a response
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return $this
      */
-    public function runReadCommand(CommandInterface $query);
+    public function runReadCommand($query);
 
     /**
      * Passes to driver: executes a write command without waiting for a response
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      * @return $this
      */
-    public function runWriteCommand(CommandInterface $command);
+    public function runWriteCommand($command);
 }

--- a/src/Drivers/AbstractDriver.php
+++ b/src/Drivers/AbstractDriver.php
@@ -15,6 +15,11 @@ abstract class AbstractDriver extends Collection implements DriverInterface
     const FORMAT_CUSTOM = 50;
 
     /**
+     * @var array The supported languages and their processors
+     */
+    protected $languages = [];
+
+    /**
      * @var bool whether or not the driver is currently handling an open transaction
      */
     public $inTransaction = false;
@@ -27,5 +32,37 @@ abstract class AbstractDriver extends Collection implements DriverInterface
         }
         //close driver
         $this->close();
+    }
+
+    /**
+     * Checks if a language is supported by this driver
+     *
+     * @param string $language the language identifier, (orientSQL, gremlin, cypher)
+     *
+     * @return bool
+     */
+    public function isSupportedLanguage($language)
+    {
+        foreach($this->languages as $lang => $processor)
+        {
+            if($lang == $language)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the processor for a given language
+     *
+     * @param string $language the language identifier, (orientSQL, gremlin, cypher)
+     *
+     * @return ProcessorInterface
+     */
+    public function getProcessor($language)
+    {
+        $class = static::$languages[$language];
+        return new $class;
     }
 }

--- a/src/Drivers/AbstractDriver.php
+++ b/src/Drivers/AbstractDriver.php
@@ -43,12 +43,8 @@ abstract class AbstractDriver extends Collection implements DriverInterface
      */
     public function isSupportedLanguage($language)
     {
-        foreach($this->languages as $lang => $processor)
-        {
-            if($lang == $language)
-            {
-                return true;
-            }
+        if (isset($this->languages[$language])) {
+            return true;
         }
         return false;
     }
@@ -62,7 +58,7 @@ abstract class AbstractDriver extends Collection implements DriverInterface
      */
     public function getProcessor($language)
     {
-        $class = static::$languages[$language];
+        $class = $this->languages[$language];
         return new $class;
     }
 }

--- a/src/Drivers/DriverInterface.php
+++ b/src/Drivers/DriverInterface.php
@@ -32,36 +32,36 @@ interface DriverInterface extends ManagesItemsInterface
      *
      * This is the R in CRUD
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return Response
      */
-    public function executeReadCommand(CommandInterface $query);
+    public function executeReadCommand($query);
 
     /**
      * Executes a write command
      *
      * These are the "CUD" in CRUD
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      * @return Response
      */
-    public function executeWriteCommand(CommandInterface $command);
+    public function executeWriteCommand($command);
 
     /**
      * Executes a read command without waiting for a response
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return $this
      */
-    public function runReadCommand(CommandInterface $query);
+    public function runReadCommand($query);
 
     /**
      * Executes a write command without waiting for a response
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      * @return $this
      */
-    public function runWriteCommand(CommandInterface $command);
+    public function runWriteCommand($command);
 
     /**
      * Opens a transaction

--- a/src/Drivers/Gremlin/Driver.php
+++ b/src/Drivers/Gremlin/Driver.php
@@ -83,7 +83,7 @@ class Driver extends AbstractDriver implements DriverInterface
     /**
      * Executes a Query or read command
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return Response
      * @throws \Exception
      * @throws \brightzone\rexpro\ServerException
@@ -115,7 +115,7 @@ class Driver extends AbstractDriver implements DriverInterface
      *
      * These are the "CUD" in CRUD
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      *
      * @return Response
      */
@@ -127,7 +127,7 @@ class Driver extends AbstractDriver implements DriverInterface
     /**
      * Executes a read command without waiting for a response
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return $this
      * @throws \Exception
      * @throws \brightzone\rexpro\ServerException
@@ -142,7 +142,7 @@ class Driver extends AbstractDriver implements DriverInterface
     /**
      * Executes a write command without waiting for a response
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      *
      * @return $this
      */

--- a/tests/Stubs/CommandProcessorStub.php
+++ b/tests/Stubs/CommandProcessorStub.php
@@ -21,7 +21,6 @@ class CommandProcessorStub implements ProcessorInterface
     public function process(Bag $bag)
     {
         $command = new Command(json_encode($bag));
-        $command->setRw('read');
         return $command;
     }
 }

--- a/tests/Stubs/DriverStub.php
+++ b/tests/Stubs/DriverStub.php
@@ -62,10 +62,10 @@ class DriverStub extends AbstractDriver implements DriverInterface
      *
      * This is the R in CRUD
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return array|Record|Graph
      */
-    public function executeReadCommand(CommandInterface $query)
+    public function executeReadCommand($query)
     {
         return new Response(['_raw' => '', '_driver' => $this]);
     }
@@ -75,34 +75,36 @@ class DriverStub extends AbstractDriver implements DriverInterface
      *
      * These are the "CUD" in CRUD
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      * @return Graph|Record|array|mixed mixed values for some write commands
      */
-    public function executeWriteCommand(CommandInterface $command)
+    public function executeWriteCommand($command)
     {
-        $this->executeReadCommand($command);
+        return $this->executeReadCommand($command);
     }
 
     /**
      * Executes a read command without waiting for a response
      *
-     * @param CommandInterface $query
+     * @param CommandInterface|BaseBuilder $query
      * @return $this
      */
-    public function runReadCommand(CommandInterface $query)
+    public function runReadCommand($query)
     {
-        // Nothing
+        $this->executeReadCommand($command);
+        return $this;
     }
 
     /**
      * Executes a write command without waiting for a response
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|BaseBuilder $command
      * @return $this
      */
-    public function runWriteCommand(CommandInterface $command)
+    public function runWriteCommand($command)
     {
-        // Nothing
+        $this->executeWriteCommand($command);
+        return $this;
     }
         /**
      * Opens a transaction

--- a/tests/Unit/Commands/Builders/BaseBuilder/BaseTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/BaseTest.php
@@ -12,7 +12,7 @@ class BaseTest extends TestSetup
     /* Manage the Command Bag */
     public function testCreateBag()
     {
-        $this->assertEquals(new Bag(), $this->builder->getCommandBag(), "failed to return an empty bag");
+        $this->assertEquals(new Bag(), $this->builder->getBag(), "failed to return an empty bag");
     }
 
     public function testClearBag()
@@ -23,7 +23,7 @@ class BaseTest extends TestSetup
 
         $this->builder->clear();
 
-        $this->assertEquals(new Bag(), $this->builder->getCommandBag(), "failed to return an empty bag");
+        $this->assertEquals(new Bag(), $this->builder->getBag(), "failed to return an empty bag");
     }
 
     /* Projections tests */
@@ -32,7 +32,7 @@ class BaseTest extends TestSetup
     {
         $this->specify("it returns nothing by default", function () {
             $actual = $this->builder
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'projections' => []
@@ -44,7 +44,7 @@ class BaseTest extends TestSetup
         $this->specify("it returns a single value", function () {
             $actual = $this->builder
                 ->projections('username')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'projections' => ['username']
@@ -56,7 +56,7 @@ class BaseTest extends TestSetup
         $this->specify("it several properties from array", function () {
             $actual = $this->builder
                 ->projections(['username', 'password'])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'projections' => ['username', 'password']
@@ -68,7 +68,7 @@ class BaseTest extends TestSetup
         $this->specify("it several properties from csv string (one space)", function () {
             $actual = $this->builder
                 ->projections('username, password')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'projections' => ['username', 'password']
@@ -80,7 +80,7 @@ class BaseTest extends TestSetup
         $this->specify("it returns several properties from csv string (no spaces)", function () {
             $actual = $this->builder
                 ->projections('username,password')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'projections' => ['username', 'password']
@@ -92,7 +92,7 @@ class BaseTest extends TestSetup
         $this->specify("it returns several properties from csv string (many spaces)", function () {
             $actual = $this->builder
                 ->projections('username,           password')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'projections' => ['username', 'password']
@@ -106,7 +106,7 @@ class BaseTest extends TestSetup
                 ->retrieve()
                 ->target('target')// byId() alias
                 ->projections(3)
-                ->getCommandBag();
+                ->getBag();
 
         }, ['throws' => new \InvalidArgumentException("Projections must be a comma-separated string or an array")]);
 

--- a/tests/Unit/Commands/Builders/BaseBuilder/CreateTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/CreateTest.php
@@ -21,7 +21,7 @@ class CreateTest extends TestSetup
             $actual = $this->builder
                 ->target('target')
                 ->create($record)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_CREATE,
@@ -42,7 +42,7 @@ class CreateTest extends TestSetup
             $actual = $this->builder
                 ->target('target')
                 ->create($records)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_CREATE,

--- a/tests/Unit/Commands/Builders/BaseBuilder/DeleteTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/DeleteTest.php
@@ -14,7 +14,7 @@ class DeleteTest extends TestSetup
         $this->specify("it drops a single record dispatching from `delete()`", function () {
             $actual = $this->builder
                 ->delete()
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_DELETE

--- a/tests/Unit/Commands/Builders/BaseBuilder/RetrieveTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/RetrieveTest.php
@@ -21,7 +21,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->where('certified', 'yes')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -41,7 +41,7 @@ class RetrieveTest extends TestSetup
                 ->target("V")
                 ->where('name', 'michael')
                 ->where('certified', true)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -62,7 +62,7 @@ class RetrieveTest extends TestSetup
                 ->target("V")
                 ->where(['name', '=', 'michael'])
                 ->where('certified', true)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -85,7 +85,7 @@ class RetrieveTest extends TestSetup
                     ['name', '=', 'michael'],
                     ['price', '>', 2]
                 ])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -106,7 +106,7 @@ class RetrieveTest extends TestSetup
                 ->target("V")
                 ->where('certified', true)
                 ->where(['name', '=', 'michael', 'OR'])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -130,7 +130,7 @@ class RetrieveTest extends TestSetup
                     ['name', '=', 'michael'],
                     ['price', '>', 2, 'OR']
                 ])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -153,7 +153,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->limit(2)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -173,7 +173,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->groupBy('certified')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -190,7 +190,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->groupBy(['certified', 'price'])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -207,7 +207,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->groupBy('certified, price')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -227,7 +227,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->orderBy('price')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -244,7 +244,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->orderBy('price')->desc()
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -262,7 +262,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->orderBy('price')->asc()
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -280,7 +280,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->orderBy(['price', 'owner'])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -298,7 +298,7 @@ class RetrieveTest extends TestSetup
                 ->retrieve()
                 ->target("V")
                 ->orderBy('price, owner')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,

--- a/tests/Unit/Commands/Builders/BaseBuilder/UpdateTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/UpdateTest.php
@@ -15,7 +15,7 @@ class UpdateTest extends TestSetup
         $this->specify("it updates a single record with a single value by ID", function () {
             $actual = $this->builder
                 ->update('name', 'chris')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_UPDATE,
@@ -31,7 +31,7 @@ class UpdateTest extends TestSetup
                 ->where('username', 'chrismichaels84')
                 ->target('users')
                 ->limit(1)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_UPDATE,
@@ -50,7 +50,7 @@ class UpdateTest extends TestSetup
                     'name' => 'chris',
                     'birthday' => 'april'
                 ])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_UPDATE,
@@ -70,7 +70,7 @@ class UpdateTest extends TestSetup
                 ->update()
                 ->target('target')
                 ->data($data) // alias withData()
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_UPDATE,

--- a/tests/Unit/Commands/Builders/Builder/BaseTest.php
+++ b/tests/Unit/Commands/Builders/Builder/BaseTest.php
@@ -18,7 +18,7 @@ class BaseTest extends TestSetup
         $this->specify("it adds a single record id via `record()`", function () {
             $actual = $this->builder
                 ->record(3)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'target' => new TargetID(3)
@@ -30,7 +30,7 @@ class BaseTest extends TestSetup
         $this->specify("it adds multiple records via ids", function () {
             $actual = $this->builder
                 ->records([1, 2, 3])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'target' => [
@@ -72,7 +72,7 @@ class BaseTest extends TestSetup
 
             $actual = $this->builder
                 ->tree()
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'map' => Bag::MAP_TREE
@@ -86,7 +86,7 @@ class BaseTest extends TestSetup
 
             $actual = $this->builder
                 ->path()
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                  'map' => Bag::MAP_PATH

--- a/tests/Unit/Commands/Builders/Builder/CreateTest.php
+++ b/tests/Unit/Commands/Builders/Builder/CreateTest.php
@@ -21,7 +21,7 @@ class CreateTest extends TestSetup
             $actual = $this->builder
                 ->into('target')
                 ->insert($record)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_CREATE,

--- a/tests/Unit/Commands/Builders/Builder/DeleteTest.php
+++ b/tests/Unit/Commands/Builders/Builder/DeleteTest.php
@@ -14,7 +14,7 @@ class DeleteTest extends TestSetup
         $this->specify("it drops a single record dispatching from `drop()`", function () {
             $actual = $this->builder
                 ->drop(3)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_DELETE,
@@ -27,7 +27,7 @@ class DeleteTest extends TestSetup
         $this->specify("it drops multiple records dispatching from `drop()`", function () {
             $actual = $this->builder
                 ->drop([1, 2, 3])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_DELETE,
@@ -46,7 +46,7 @@ class DeleteTest extends TestSetup
                 ->drop()
                 ->from('target')
                 ->where('birthday', 'apr')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_DELETE,

--- a/tests/Unit/Commands/Builders/Builder/RetrieveTest.php
+++ b/tests/Unit/Commands/Builders/Builder/RetrieveTest.php
@@ -17,7 +17,7 @@ class RetrieveTest extends TestSetup
             $actual = $this->builder
                 ->select(['price', 'certified'])
                 ->record("#12:6767")// byId() alias
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -33,7 +33,7 @@ class RetrieveTest extends TestSetup
                 ->select()
                 ->record("#12:6767")// byId() alias
                 ->only(['price', 'certified'])
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -48,7 +48,7 @@ class RetrieveTest extends TestSetup
             $actual = $this->builder
                 ->select()
                 ->from("V")
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -69,7 +69,7 @@ class RetrieveTest extends TestSetup
                 ->where('name', 'michael')
                 ->andWhere('last', 'wilson')
                 ->andWhere('certified', true)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -92,7 +92,7 @@ class RetrieveTest extends TestSetup
                 ->where('name', 'michael')
                 ->orWhere('last', 'wilson')
                 ->orWhere('certified', true)
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,
@@ -116,7 +116,7 @@ class RetrieveTest extends TestSetup
                 ->select()
                 ->from('v')
                 ->first()
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_RETRIEVE,

--- a/tests/Unit/Commands/Builders/Builder/UpdateTest.php
+++ b/tests/Unit/Commands/Builders/Builder/UpdateTest.php
@@ -16,7 +16,7 @@ class UpdateTest extends TestSetup
                 ->updateFirst('users')
                 ->where('username', 'chrismichaels84')
                 ->data('name', 'chris')
-                ->getCommandBag();
+                ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_UPDATE,

--- a/tests/Unit/Commands/Languages/OrientSqlProcessorTest.php
+++ b/tests/Unit/Commands/Languages/OrientSqlProcessorTest.php
@@ -101,7 +101,6 @@ class OrientSqlProcessorTest extends BaseTestSuite
 
         $command = new Command($query);
         $command->setScriptLanguage('OrientSQL');
-        $command->setRw('read');
         return $command;
     }
 
@@ -117,7 +116,6 @@ class OrientSqlProcessorTest extends BaseTestSuite
 
         $command = new Command($query);
         $command->setScriptLanguage('OrientSQL');
-        $command->setRw('read');
         return $command;
     }
 
@@ -136,7 +134,6 @@ class OrientSqlProcessorTest extends BaseTestSuite
 
         $command = new Command($query);
         $command->setScriptLanguage('OrientSQL');
-        $command->setRw('read');
         return $command;
     }
 

--- a/tests/Unit/Drivers/Gremlin/DriverTest.php
+++ b/tests/Unit/Drivers/Gremlin/DriverTest.php
@@ -16,7 +16,7 @@ class DriverTest extends BaseTestSuite
 
     public function setup()
     {
-        $this->markTestSkipped("Test Database Not Installed");
+        //$this->markTestSkipped("Test Database Not Installed");
     }
 
     /* Implemented Methods */
@@ -61,7 +61,7 @@ class DriverTest extends BaseTestSuite
     {
         $query = $this->driver->traversal . ".V().has('name', 'marko').limit(1)";
         return [
-            'command' => new Command($query),
+            'command' => new Command($query, 'gremlin'),
             'expected' => [
                 [
                     'id' => 1,
@@ -95,7 +95,7 @@ class DriverTest extends BaseTestSuite
     public function selectTwoItems()
     {
         return [
-            'command' => new Command($this->driver->traversal . ".V().limit(2)"),
+            'command' => new Command($this->driver->traversal . ".V().limit(2)", 'gremlin'),
             'expected' => [
                 [
                     'id' => 1,
@@ -121,7 +121,7 @@ class DriverTest extends BaseTestSuite
     {
         return [
             'command' => new Command(
-                $this->driver->traversal . ".V().has('name', '$name')"
+                $this->driver->traversal . ".V().has('name', '$name')", 'gremlin'
             ),
             'expected' => []
         ];
@@ -137,7 +137,7 @@ class DriverTest extends BaseTestSuite
         $query = $this->driver->graph . ".addVertex('name', 'testVertex')";
 
         return [
-            'command' => new Command($query),
+            'command' => new Command($query, 'gremlin'),
             'expected' => [
                 [
                     'name' => 'testVertex',
@@ -157,7 +157,7 @@ class DriverTest extends BaseTestSuite
         $query = $this->driver->traversal . ".V().has('name', '$name').property('name', 'testVertex2')";
 
         return [
-            'command' => new Command($query),
+            'command' => new Command($query, 'gremlin'),
             'expected' => [
                 [
                     'name' => 'testVertex2'
@@ -177,7 +177,7 @@ class DriverTest extends BaseTestSuite
         $query = $this->driver->traversal . ".V().has('name', '$name').drop().iterate()";
 
         return [
-            'command' => new Command($query),
+            'command' => new Command($query, 'gremlin'),
             'expected' => [],
         ];
     }

--- a/tests/Unit/Drivers/Neo4J/DriverTest.php
+++ b/tests/Unit/Drivers/Neo4J/DriverTest.php
@@ -14,7 +14,7 @@ class DriverTest extends BaseTestSuite
 {
     public function setup()
     {
-        $this->markTestSkipped("Test Database Not Installed");
+        //$this->markTestSkipped("Test Database Not Installed");
     }
 
     /** Returns an instance of the configured driver
@@ -52,7 +52,7 @@ class DriverTest extends BaseTestSuite
             'command' => new Command(
                 "MATCH (a {name:'marko'})
                  RETURN a
-                 LIMIT 1"
+                 LIMIT 1", "cypher"
             ),
             'expected' => [
                 [
@@ -90,7 +90,7 @@ class DriverTest extends BaseTestSuite
             'command' => new Command(
                 "MATCH (a)
                  RETURN a
-                 LIMIT 2"
+                 LIMIT 2", "cypher"
             ),
             'expected' => [
                 [
@@ -117,7 +117,7 @@ class DriverTest extends BaseTestSuite
     {
         return [
             'command' => new Command(
-                "MATCH (a {name:'$name'}) RETURN a"
+                "MATCH (a {name:'$name'}) RETURN a", "cypher"
             ),
             'expected' => []
         ];
@@ -131,7 +131,7 @@ class DriverTest extends BaseTestSuite
     public function createOneItem()
     {
         return [
-            'command' => new Command("CREATE (a {name:'testVertex'}) RETURN a"),
+            'command' => new Command("CREATE (a {name:'testVertex'}) RETURN a", "cypher"),
             'expected' => [
                 [
                     'name' => 'testVertex',
@@ -153,7 +153,7 @@ class DriverTest extends BaseTestSuite
                     RETURN a";
 
         return [
-            'command' => new Command($query),
+            'command' => new Command($query, "cypher"),
             'expected' => [
                 [
                     'name' => 'testVertex2'
@@ -174,7 +174,7 @@ class DriverTest extends BaseTestSuite
                     DELETE a";
 
         return [
-            'command' => new Command($query),
+            'command' => new Command($query, "cypher"),
             'expected' => [],
         ];
     }
@@ -217,7 +217,7 @@ class DriverTest extends BaseTestSuite
         $response = $driver->executeReadCommand(new Command(
             "MATCH p =((a)-[:created]->(b)<-[:created]-(c))
              RETURN p
-             LIMIT 1"
+             LIMIT 1", "cypher"
         ));
         $consistent = $response->getPath();
         $this->assertTrue(is_array($consistent), 'the formatted response is not an array');
@@ -238,7 +238,7 @@ class DriverTest extends BaseTestSuite
         $response = $driver->executeReadCommand(new Command(
             "MATCH p =((a)-[:created]->(b)<-[:created]-(c))
              RETURN p
-             LIMIT 2"
+             LIMIT 2", "cypher"
         ));
         $consistent = $response->getPath();
         $this->assertTrue(is_array($consistent), 'the formatted response is not an array');

--- a/tests/Unit/Drivers/OrientDB/DriverTest.php
+++ b/tests/Unit/Drivers/OrientDB/DriverTest.php
@@ -14,7 +14,7 @@ class DriverTest extends BaseTestSuite
 {
     public function setup()
     {
-        $this->markTestSkipped("Test Database Not Installed");
+        //$this->markTestSkipped("Test Database Not Installed");
     }
 
     /** Returns an instance of the configured driver
@@ -50,7 +50,7 @@ class DriverTest extends BaseTestSuite
     public function selectOneItem()
     {
         return [
-            'command' => new Command("SELECT FROM V WHERE @rid = #9:1"),
+            'command' => new Command("SELECT FROM V WHERE @rid = #9:1", "orientSQL"),
             'expected' => [
                 [
                     'id' => '#9:1',
@@ -85,7 +85,7 @@ class DriverTest extends BaseTestSuite
     {
         return [
             'command' => new Command(
-                "SELECT FROM V WHERE song_type = 'cover' LIMIT 2"
+                "SELECT FROM V WHERE song_type = 'cover' LIMIT 2", "orientSQL"
             ),
             'expected' => [
                 [
@@ -111,7 +111,7 @@ class DriverTest extends BaseTestSuite
     public function selectByName($name)
     {
         return [
-            'command' => new Command("SELECT FROM V WHERE name = '$name'"),
+            'command' => new Command("SELECT FROM V WHERE name = '$name'", "orientSQL"),
             'expected' => [],
         ];
     }
@@ -125,7 +125,7 @@ class DriverTest extends BaseTestSuite
     {
         return [
             'command' => new Command(
-                "CREATE Vertex CONTENT " . json_encode(['name' => 'testVertex'])
+                "CREATE Vertex CONTENT " . json_encode(['name' => 'testVertex']), "orientSQL"
             ),
             'expected' => [
                 [
@@ -147,7 +147,7 @@ class DriverTest extends BaseTestSuite
         $query .= "MERGE " . json_encode(['name' => 'testVertex2']) . ' RETURN AFTER $current';
 
         return [
-            'command' => new Command($query),
+            'command' => new Command($query, "orientSQL"),
             'expected' => [
                 [
                     'name' => 'testVertex2',
@@ -165,7 +165,7 @@ class DriverTest extends BaseTestSuite
     public function deleteOneItem($name)
     {
         return [
-            'command' => new Command("DELETE VERTEX WHERE name = '$name'"),
+            'command' => new Command("DELETE VERTEX WHERE name = '$name'", "orientSQL"),
             'expected' => []
         ];
     }
@@ -208,15 +208,15 @@ class DriverTest extends BaseTestSuite
             $driver->startTransaction();
 
             $driver->executeWriteCommand(new Command(
-                "CREATE VERTEX CONTENT {name:'one'}"
+                "CREATE VERTEX CONTENT {name:'one'}", "orientSQL"
             ));
 
             $driver->executeWriteCommand(new Command(
-                "CREATE VERTEX CONTENT {name:'two'}"
+                "CREATE VERTEX CONTENT {name:'two'}", "orientSQL"
             ));
 
             $driver->executeWriteCommand(new Command(
-                "CREATE VERTEX CONTENT {name:'three'}"
+                "CREATE VERTEX CONTENT {name:'three'}", "orientSQL"
             ));
 
             $expected = "begin\n";
@@ -243,5 +243,18 @@ class DriverTest extends BaseTestSuite
     public function testFormatPath()
     {
         $this->markTestSkipped("Path is not yet implemented as orient doesn't currently support it");
+    }
+
+    public function testPassingBuilder()
+    {
+        $builder = new \Spider\Commands\Builder();
+        $builder->select()->from('V');
+        $driver = $this->driver();
+        $driver->open();
+
+        $response = $driver->executeReadCommand($builder);
+
+        $consistent = $response->getSet();
+        $this->assertEquals(20, count($consistent), "wrong number of elements found");
     }
 }


### PR DESCRIPTION
There are a few things covered in this PR:
- [ ] `Builder::getScript($processor)` now returns a string
- [ ] `Builder::getCommand($processor)` replaces the old `getScript()` (I've also moved both up to the `BaseBuilder`.)
- [ ] I removed `getRw()` and `setRw()` as these weren't necessary. The `Command` doesn't have any authority  over the driver. It's now the `Query` or user's job to decide which scenario (R/W) we're in and act accordingly.
- [ ] `Query` no longer requires a `Processor`. It now delegates the processing work to the Driver. If you still decide to provide a processor to the query then that one will be used instead and a `Command` will be passed to the driver.
- [ ] a set of methods in `AbstractDriver` help the drivers convert `Builder` into `Command` depending on available languages. 

---

Things to keep in mind:
- The current implementation of converting `Builder` to `Command` in the drivers is verbose and an ugly copy/paste. We can change this once we have the other processors up and running, we'll just create a method in `AbstractDriver` to handle this. Should make the code much cleaner. 
- Other PRs will need to rebase around this one. (I think it'll be easier this way around rather than rebasing this against the other PRs)
- Currently have a very simple Builder to Command Driver test for Orient. We will need to move this up to `BaseDriverTest` once we have at least a cypher processor.
- There are no added tests here for `Query`. Main reason being that the best place for this would be in the integration tests and that's in another PR. We can add it after as we go through code coverage.
