### PR TITLE
Added a neo4j, orient, and gremlin-server build configuration for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,25 @@ php:
   - hhvm
   - nightly
 
+matrix:
+  allow_failures:
+    - php: nightly
+env:
+  - NEO4J_VERSION="2.2.4" GREMLINSERVER_VERSION="3.0.0" ORIENT_VERSION="2.1.0"
+
+before_install:
+  - sudo apt-get update > /dev/null
+
+install:
+  # install Oracle JDK8
+  - sh -c ./CI/jdk8-install.sh
+  # install gremlin-server
+  - sh -c ./CI/gremlin-server/install.sh
+  # install neo4j
+  - sh -c ./CI/neo4j/install.sh
+  # install orient
+  - sh -c ./CI/orient/install.sh
+
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev
@@ -17,4 +36,4 @@ script:
 
 after_script:
   - php vendor/bin/coveralls -v
-  
+

--- a/CI/gremlin-server/gremlin-server-spider.yaml
+++ b/CI/gremlin-server/gremlin-server-spider.yaml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+host: localhost
+port: 8182
+threadPoolWorker: 1
+gremlinPool: 8
+scriptEvaluationTimeout: 30000
+serializedResponseTimeout: 30000
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphs: {
+  graph: conf/tinkergraph-empty.properties ,
+  graphT: conf/neo4j-empty.properties
+}
+plugins:
+  - tinkerpop.neo4j
+  - tinkerpop.tinkergraph
+scriptEngines: {
+  gremlin-groovy: {
+    imports: [java.lang.Math],
+    staticImports: [java.lang.Math.PI],
+    scripts: [scripts/gremlin-spider-script.groovy]},
+  nashorn: {
+      imports: [java.lang.Math],
+      staticImports: [java.lang.Math.PI]}}
+serializers:
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0 }                                             # application/vnd.gremlin-v1.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }                                  # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }                                         # application/json
+processors:
+  - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
+metrics: {
+  consoleReporter: {enabled: true, interval: 180000},
+  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  jmxReporter: {enabled: true},
+  slf4jReporter: {enabled: true, interval: 180000},
+  gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
+  graphiteReporter: {enabled: false, interval: 180000}}
+threadPoolBoss: 1
+maxInitialLineLength: 4096
+maxHeaderSize: 8192
+maxChunkSize: 8192
+maxContentLength: 65536
+maxAccumulationBufferComponents: 1024
+resultIterationBatchSize: 64
+writeBufferHighWaterMark: 32768
+writeBufferHighWaterMark: 65536
+ssl: {
+  enabled: false}

--- a/CI/gremlin-server/gremlin-spider-script.groovy
+++ b/CI/gremlin-server/gremlin-spider-script.groovy
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// defines a sample LifeCycleHook that prints some output to the Gremlin Server console.
+// it is important that the hook be assigned to a variable (in this case "hook").
+// the exact name of this variable is unimportant.
+hook = [
+  onStartUp: { ctx ->
+    ctx.logger.info("Executed once at startup of Gremlin Server.");
+  },
+  onShutDown: { ctx ->
+    ctx.logger.info("Executed once at shutdown of Gremlin Server.")
+  }
+] as LifeCycleHook
+
+// define the default TraversalSource to bind queries to.
+t = graphT.traversal()
+g = graph.traversal()
+
+// An example of an initialization script that can be configured to run in Gremlin Server.
+// Functions defined here will go into global cache and will not be removed from there
+// unless there is a reset of the ScriptEngine.
+//def addItUp(x, y) { x + y }

--- a/CI/gremlin-server/install.sh
+++ b/CI/gremlin-server/install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Add environment java vars
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+export JRE_HOME=/usr/lib/jvm/java-8-oracle
+
+# Install gremlin-server
+wget --no-check-certificate -O $HOME/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating-bin.zip https://www.apache.org/dist/incubator/tinkerpop/$GREMLINSERVER_VERSION-incubating/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating-bin.zip
+unzip $HOME/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating-bin.zip -d $HOME/
+
+# get gremlin-server configuration files
+cp ./CI/gremlin-server/gremlin-spider-script.groovy $HOME/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating/scripts/
+cp ./CI/gremlin-server/gremlin-server-spider.yaml $HOME/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating/conf/
+
+# get neo4j dependencies
+cd $HOME/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating
+bin/gremlin-server.sh -i org.apache.tinkerpop neo4j-gremlin $GREMLINSERVER_VERSION-incubating
+
+# Start gremlin-server in the background and wait for it to be available
+bin/gremlin-server.sh conf/gremlin-server-spider.yaml > /dev/null 2>&1 &
+cd $TRAVIS_BUILD_DIR
+sleep 30

--- a/CI/jdk8-install.sh
+++ b/CI/jdk8-install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Get dependencies (for adding repos)
+sudo apt-get install -y python-software-properties
+sudo add-apt-repository -y ppa:webupd8team/java
+sudo apt-get update
+
+# install oracle jdk 8
+sudo apt-get install -y oracle-java8-installer
+sudo update-alternatives --auto java
+sudo update-alternatives --auto javac
+
+# Add to environment
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+export JRE_HOME=/usr/lib/jvm/java-8-oracle

--- a/CI/neo4j/install.sh
+++ b/CI/neo4j/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Add environment java vars
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+export JRE_HOME=/usr/lib/jvm/java-8-oracle
+
+# install Neo4j locally:
+wget -O $HOME/neo4j-community-$NEO4J_VERSION-unix.tar.gz dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz
+tar -xzf $HOME/neo4j-community-$NEO4J_VERSION-unix.tar.gz -C $HOME/
+$HOME/neo4j-community-$NEO4J_VERSION/bin/neo4j start
+
+# changing password:
+curl -vX POST http://neo4j:neo4j@localhost:7474/user/neo4j/password -d"password=j4oen"

--- a/CI/orient/install.sh
+++ b/CI/orient/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Add environment java vars
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+export JRE_HOME=/usr/lib/jvm/java-8-oracle
+
+# Download orient
+wget -O $HOME/orientdb-community-$ORIENT_VERSION.tar.gz wget http://www.orientechnologies.com/download.php?file=orientdb-community-$ORIENT_VERSION.tar.gz
+tar -xzf $HOME/orientdb-community-$ORIENT_VERSION.tar.gz -C $HOME/
+
+#update config with correct user/password
+sed -i '/<users>/a <user name="root" password="root" resources="*"><\/user>' $HOME/orientdb-community-$ORIENT_VERSION/config/orientdb-server-config.xml
+
+# run and wait for it to init
+$HOME/orientdb-community-$ORIENT_VERSION/bin/server.sh > /dev/null 2>&1 &
+sleep 15

--- a/tests/Unit/Drivers/Gremlin/DriverTest.php
+++ b/tests/Unit/Drivers/Gremlin/DriverTest.php
@@ -20,7 +20,6 @@ class DriverTest extends BaseTestSuite
         $this->fixture = new GremlinFixture();
         $this->fixture->unload();
         $this->fixture->load();
-        $this->markTestSkipped("Test Database Not Installed");
     }
 
     public function teardown()

--- a/tests/Unit/Drivers/Neo4J/DriverTest.php
+++ b/tests/Unit/Drivers/Neo4J/DriverTest.php
@@ -19,7 +19,6 @@ class DriverTest extends BaseTestSuite
         $this->fixture = new NeoFixture();
         $this->fixture->unload();
         $this->fixture->load();
-        $this->markTestSkipped("Test Database Not Installed");
     }
 
     public function teardown()

--- a/tests/Unit/Drivers/OrientDB/DriverTest.php
+++ b/tests/Unit/Drivers/OrientDB/DriverTest.php
@@ -20,7 +20,6 @@ class DriverTest extends BaseTestSuite
         $this->fixture = new OrientFixture();
         $this->fixture->unload();
         $this->fixture->load();
-        $this->markTestSkipped("Test Database Not Installed");
     }
 
     public function teardown()


### PR DESCRIPTION
This PR covers setting up Neo4J, Orient, and gremlin-server in travis. It also removes the `markedAsSkipped` from driver tests.
I've set up nightly PHP builds to be optional (not failure binding) as it can be a little unstable and in our case one of the neo libraries fail. 
Other than that all tests pass for the other builds so this should be good to go. The suit takes about 5mn to run so it's still acceptable (can't really do better on a free travis account). 

It does **not** cover anything beyond the unit tests. So no coveralls or scrutinizer, etc. We will need to add those hooks in.

covers issues #35 & part of #57 
