### PR TITLE
fixes bug #63 and a bug in the OrientSQL processor order by clauses

### DIFF
--- a/src/Commands/Languages/OrientSQL/CommandProcessor.php
+++ b/src/Commands/Languages/OrientSQL/CommandProcessor.php
@@ -38,6 +38,9 @@ class CommandProcessor implements ProcessorInterface
 
         Bag::CONJUNCTION_AND => 'AND',
         Bag::CONJUNCTION_OR => 'OR',
+
+        Bag::ORDER_DESC => 'DESC',
+        Bag::ORDER_ASC => 'ASC',
     ];
 
     /** @var  Bag The CommandBag to be processed */
@@ -341,7 +344,7 @@ class CommandProcessor implements ProcessorInterface
 
             $orders = [];
             foreach ($this->bag->orderBy as $field) {
-                $orders[] = "$field[0] $field[1]";
+                $orders[] = "$field[0] " . $this->toSqlOperator($field[1]);
             }
 
             $this->addToScript(implode(", ", $orders));

--- a/tests/Integration/QueryBuilder/BaseTestSuite.php
+++ b/tests/Integration/QueryBuilder/BaseTestSuite.php
@@ -2,6 +2,7 @@
 namespace Spider\Test\Integration\QueryBuilder;
 
 use Codeception\Specify;
+use Spider\Commands\Languages\OrientSQL\CommandProcessor;
 use Spider\Test\Fixtures\Graph;
 use Spider\Commands\Bag;
 
@@ -261,6 +262,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
                 ->from('person')
                 ->where('name', 'marko')
                 ->orWhere('name', 'peter')
+                ->orderBy('name')
                 ->all();
 
             $expected = array_filter($this->expected, function ($record) {
@@ -285,14 +287,26 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
                 ->select()
                 ->from('person')
                 ->limit(3)
+                ->orderBy('name')
                 ->get();
 
+            /* Setup the expected data */
+            // only persons
             $expected = array_filter($this->expected, function ($record) {
                 return $record['label'] === 'person';
             });
 
-            $expected = array_slice($expected, 0, 3);
+            // In the right order
+            foreach ($expected as $key => $row) {
+                $name[$key]  = $row['name'];
+            }
+            array_multisort($name, SORT_ASC, $expected);
 
+            // First three results
+            $expected = array_slice($expected, 0, 3);
+            $expected = array_values($expected);
+
+            /* Assertions */
             $this->assertTrue(is_array($response), 'failed to return an array');
             $this->assertCount(3, $response, 'failed to return the correct number of records');
 

--- a/tests/Unit/Commands/Languages/BaseTestSuite.php
+++ b/tests/Unit/Commands/Languages/BaseTestSuite.php
@@ -214,8 +214,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $bag->projections = ['field1', 'field2'];
             $bag->target = Bag::ELEMENT_VERTEX;
             $bag->limit = 3;
-            $bag->orderBy = [['field1', 'DESC']];
-            $bag->orderAsc = false;
+            $bag->orderBy = [['field1', Bag::ORDER_DESC]];
             $bag->where = array_merge($this->getWheres(), [[
                 Bag::ELEMENT_LABEL,
                 Bag::COMPARATOR_EQUAL, // convert to constant


### PR DESCRIPTION
This orders the queries in the integration tests so Neo4j passes consistently. In the process, I uncovered a bug in the orient command processor that was also corrected.
