### PR TITLE
0.3.1

### DIFF
--- a/src/Commands/Languages/Cypher/CommandProcessor.php
+++ b/src/Commands/Languages/Cypher/CommandProcessor.php
@@ -315,6 +315,10 @@ class CommandProcessor implements ProcessorInterface
     protected function buildOrderBy()
     {
         // Perform compliance check
+        if (!$this->bag->orderBy) {
+            return '';
+        }
+
         $orders = [];
         foreach ($this->bag->orderBy as $order) {
             $direction = ($order[1] === Bag::ORDER_ASC) ? 'ASC' : 'DESC';
@@ -349,11 +353,11 @@ class CommandProcessor implements ProcessorInterface
         $set = [];
         foreach ($data as $key => $value) {
             switch ($key) {
-                case Bag::ELEMENT_LABEL :
+                case Bag::ELEMENT_LABEL:
                     // @todo change to use appropriate variable when traversals are added.
                     $set[] = end($this->variables) . ' :' . $value;
                     break;
-                case Bag::ELEMENT_ID :
+                case Bag::ELEMENT_ID:
                     throw new NotSupportedException('Neo4J will not allow you to manually set IDs');
                 default:
                     $set[] = $this->detailField($key) . ' = ' . $this->castValue($value);

--- a/src/Commands/Languages/OrientSQL/CommandProcessor.php
+++ b/src/Commands/Languages/OrientSQL/CommandProcessor.php
@@ -38,6 +38,9 @@ class CommandProcessor implements ProcessorInterface
 
         Bag::CONJUNCTION_AND => 'AND',
         Bag::CONJUNCTION_OR => 'OR',
+
+        Bag::ORDER_DESC => 'DESC',
+        Bag::ORDER_ASC => 'ASC',
     ];
 
     /** @var  Bag The CommandBag to be processed */
@@ -341,7 +344,7 @@ class CommandProcessor implements ProcessorInterface
 
             $orders = [];
             foreach ($this->bag->orderBy as $field) {
-                $orders[] = "$field[0] $field[1]";
+                $orders[] = "$field[0] " . $this->toSqlOperator($field[1]);
             }
 
             $this->addToScript(implode(", ", $orders));

--- a/src/Commands/Languages/OrientSQL/CommandProcessor.php
+++ b/src/Commands/Languages/OrientSQL/CommandProcessor.php
@@ -421,7 +421,6 @@ class CommandProcessor implements ProcessorInterface
 
     /**
      * Append update data to current script
-     * @param string $prefix
      * @throws \Exception
      */
     protected function appendUpdateData()

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -17,7 +17,7 @@ class Query extends Builder
      * Creates a new instance of the Command Builder
      * With a LanguageProcessor and Connection
      * @param ProcessorInterface $processor
-     * @param ConnectionInterface|null $connection
+     * @param ConnectionInterface $connection
      * @param Bag|null $bag
      */
     public function __construct(

--- a/src/Connections/Manager.php
+++ b/src/Connections/Manager.php
@@ -39,7 +39,7 @@ class Manager extends Collection implements ManagesItemsInterface
      * Hand alias for stored Connection
      * Hand array for implicit Connection
      *
-     * @param string|array|null $alias alias | properties | default
+     * @param string $alias alias | properties | default
      * @return Connection
      * @throws \Spider\Exceptions\ConnectionNotFoundException
      */
@@ -146,8 +146,8 @@ class Manager extends Collection implements ManagesItemsInterface
 
     /**
      * Caches a built Connection
-     * @param $alias
-     * @param $connection
+     * @param string $alias
+     * @param Connection $connection
      */
     protected function cache($alias, $connection)
     {

--- a/src/Drivers/Gremlin/Driver.php
+++ b/src/Drivers/Gremlin/Driver.php
@@ -47,7 +47,7 @@ class Driver extends AbstractDriver implements DriverInterface
     ];
 
     /**
-     * @var brightzone\rexpro\Connection The client library this driver uses to communicate with the DB
+     * @var \brightzone\rexpro\Connection The client library this driver uses to communicate with the DB
      */
     protected $client;
 

--- a/src/Drivers/Neo4J/Driver.php
+++ b/src/Drivers/Neo4J/Driver.php
@@ -49,7 +49,7 @@ class Driver extends AbstractDriver implements DriverInterface
     ];
 
     /**
-     * @var brightzone\rexpro\Connection The client library this driver uses to communicate with the DB
+     * @var \brightzone\rexpro\Connection The client library this driver uses to communicate with the DB
      */
     protected $client;
 

--- a/src/Drivers/OrientDB/Driver.php
+++ b/src/Drivers/OrientDB/Driver.php
@@ -166,7 +166,7 @@ class Driver extends AbstractDriver implements DriverInterface
 
     /**
      * Write a new clause to the transaction statement
-     * @param $statement
+     * @param string $statement
      */
     protected function writeTransactionStatement($statement)
     {
@@ -250,7 +250,7 @@ class Driver extends AbstractDriver implements DriverInterface
     /**
      * Executes actual command or query
      * @param CommandInterface|BaseBuilder $command
-     * @param $method
+     * @param string $method
      * @return Response
      * @throws NotSupportedException
      * @throws \Exception
@@ -466,7 +466,7 @@ class Driver extends AbstractDriver implements DriverInterface
     /**
      * Ensure that a response can be formatted as desired
      * @param $response
-     * @param $desiredFormat
+     * @param integer $desiredFormat
      * @throws FormattingException
      */
     protected function canFormat($response, $desiredFormat)
@@ -510,7 +510,7 @@ class Driver extends AbstractDriver implements DriverInterface
     /**
      * Can a response set be formatted as a scalar?
      * @param $response
-     * @param $e
+     * @param FormattingException $e
      * @return bool
      */
     protected function canBeScalar($response, $e)

--- a/src/Drivers/OrientDB/Driver.php
+++ b/src/Drivers/OrientDB/Driver.php
@@ -225,7 +225,7 @@ class Driver extends AbstractDriver implements DriverInterface
      * These are the "CUD" in CRUD
      *
      * @param CommandInterface|BaseBuilder $command
-     * @return Response mixed values for some write commands
+     * @return Response|null values for some write commands
      */
     public function executeWriteCommand($command)
     {

--- a/tests/Integration/QueryBuilder/BaseTestSuite.php
+++ b/tests/Integration/QueryBuilder/BaseTestSuite.php
@@ -2,6 +2,7 @@
 namespace Spider\Test\Integration\QueryBuilder;
 
 use Codeception\Specify;
+use Spider\Commands\Languages\OrientSQL\CommandProcessor;
 use Spider\Test\Fixtures\Graph;
 use Spider\Commands\Bag;
 
@@ -261,6 +262,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
                 ->from('person')
                 ->where('name', 'marko')
                 ->orWhere('name', 'peter')
+                ->orderBy('name')
                 ->all();
 
             $expected = array_filter($this->expected, function ($record) {
@@ -285,14 +287,26 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
                 ->select()
                 ->from('person')
                 ->limit(3)
+                ->orderBy('name')
                 ->get();
 
+            /* Setup the expected data */
+            // only persons
             $expected = array_filter($this->expected, function ($record) {
                 return $record['label'] === 'person';
             });
 
-            $expected = array_slice($expected, 0, 3);
+            // In the right order
+            foreach ($expected as $key => $row) {
+                $name[$key]  = $row['name'];
+            }
+            array_multisort($name, SORT_ASC, $expected);
 
+            // First three results
+            $expected = array_slice($expected, 0, 3);
+            $expected = array_values($expected);
+
+            /* Assertions */
             $this->assertTrue(is_array($response), 'failed to return an array');
             $this->assertCount(3, $response, 'failed to return the correct number of records');
 

--- a/tests/Unit/Commands/Languages/BaseTestSuite.php
+++ b/tests/Unit/Commands/Languages/BaseTestSuite.php
@@ -214,8 +214,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $bag->projections = ['field1', 'field2'];
             $bag->target = Bag::ELEMENT_VERTEX;
             $bag->limit = 3;
-            $bag->orderBy = [['field1', 'DESC']];
-            $bag->orderAsc = false;
+            $bag->orderBy = [['field1', Bag::ORDER_DESC]];
             $bag->where = array_merge($this->getWheres(), [[
                 Bag::ELEMENT_LABEL,
                 Bag::COMPARATOR_EQUAL, // convert to constant


### PR DESCRIPTION
Fixes a few bugs:
- Neo4j passes consistently. Added ordering to queries in Query test
- OrientSql Command Processor uses `orderBy` constants correctly
- Several minor scrutinizer fixes.

I haven't come across any other bugs that would warrant being released before 0.4. Is there anything else that needs to be in 0.3.1?

After I merge and release, I will merge the updates into develop and down the tree. Be sure to `pull` changes.
