### PR TITLE
Simplify drivers read/write methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All Notable changes to `Spider` will be documented in this file
 ## v0.4 - NEXT
 - Query api uses verb-based dispatch methods (getAll(), getOne(), etc)
 - Refactor: OrientDB uses SqlBatch for commands consistently
+- Simplified Drivers by replacing read/writeCommand() with single executeCommand() and runCommand()
 
 ## v0.3.1 - 9-1-2015
 - Bug: Added ordering to select tests so Neo would consistently pass #63

--- a/src/Commands/BaseBuilder.php
+++ b/src/Commands/BaseBuilder.php
@@ -23,7 +23,7 @@ class BaseBuilder
      * Creates a new instance of the Command Builder
      * With an optional language processor
      *
-     * @param ProcessorInterface $processor
+     * @param ProcessorInterface|null $processor
      * @param Bag|null $bag
      */
     public function __construct(
@@ -262,7 +262,7 @@ class BaseBuilder
 
     /**
      * Processes the current command bag
-     * @param ProcessorInterface $processor
+     * @param ProcessorInterface|null $processor
      * @return String the script in string form
      * @throws \Exception
      */
@@ -291,7 +291,7 @@ class BaseBuilder
 
     /**
      * Processes the current command bag
-     * @param ProcessorInterface $processor
+     * @param ProcessorInterface|null $processor
      * @return Command
      * @throws \Exception
      */

--- a/src/Commands/Builder.php
+++ b/src/Commands/Builder.php
@@ -33,7 +33,7 @@ class Builder extends BaseBuilder
      * Creates a new instance of the Command Builder
      * With an optional language processor
      *
-     * @param ProcessorInterface $processor
+     * @param ProcessorInterface|null $processor
      * @param Bag|null $bag
      */
     public function __construct(

--- a/src/Commands/Languages/Cypher/CommandProcessor.php
+++ b/src/Commands/Languages/Cypher/CommandProcessor.php
@@ -56,7 +56,7 @@ class CommandProcessor implements ProcessorInterface
      * script for whichever driver is specified
      *
      * @param Bag $bag
-     * @return CommandInterface
+     * @return Command
      */
     public function process(Bag $bag)
     {

--- a/src/Commands/Languages/OrientSQL/CommandProcessor.php
+++ b/src/Commands/Languages/OrientSQL/CommandProcessor.php
@@ -60,7 +60,7 @@ class CommandProcessor implements ProcessorInterface
      * script for whichever driver is specified
      *
      * @param Bag $bag
-     * @return CommandInterface
+     * @return Command
      */
     public function process(Bag $bag)
     {

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -51,11 +51,7 @@ class Query extends Builder
             $message = $this;
         }
 
-        if ($this->bag->command === Bag::COMMAND_RETRIEVE) {
-            $response = $this->connection->executeReadCommand($message);
-        } else {
-            $response = $this->connection->executeWriteCommand($message);
-        }
+        $response = $this->connection->executeCommand($message);
 
         // Reset query and return response
         $this->clear();

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -37,7 +37,7 @@ class Query extends Builder
      * If no instance of CommandInterface is provided, then the
      * current Command Bag is processed via the Command Processor
      * @param CommandInterface|null $command
-     * @return Response the DB response in SpiderResponse format
+     * @return \Spider\Drivers\Response the DB response in SpiderResponse format
      */
     protected function dispatch($command = null)
     {
@@ -61,7 +61,7 @@ class Query extends Builder
 
     /**
      * Alias of dispatch
-     * @return Response
+     * @return \Spider\Drivers\Response
      */
     public function go()
     {
@@ -145,7 +145,7 @@ class Query extends Builder
     /**
      * Execute a command through dispatch
      * @param CommandInterface|null $command
-     * @return Response
+     * @return \Spider\Drivers\Response
      */
     public function execute(CommandInterface $command = null)
     {

--- a/src/Connections/Connection.php
+++ b/src/Connections/Connection.php
@@ -121,4 +121,51 @@ class Connection extends Collection implements ConnectionInterface
             $this->driver = new $driver();
         }
     }
+
+    /**
+     * Executes a Command
+     *
+     * This is the R in CRUD
+     *
+     * @param CommandInterface|BaseBuilder $query
+     * @return Response
+     */
+    public function executeCommand($query)
+    {
+        return $this->driver->executeCommand($query);
+    }
+
+    /**
+     * Runs a Command without waiting for a response
+     *
+     * @param CommandInterface|BaseBuilder $command
+     * @return $this
+     */
+    public function runCommand($command)
+    {
+        $this->driver->runCommand($command);
+        return $this;
+    }
+
+    /**
+     * Opens a transaction
+     *
+     * @return bool
+     */
+    public function startTransaction()
+    {
+        // TODO: Implement startTransaction() method.
+    }
+
+    /**
+     * Closes a transaction
+     *
+     * @param bool $commit whether this is a commit (true) or a rollback (false)
+     *
+     * @return bool
+     */
+    public function stopTransaction($commit = true)
+    {
+        // TODO: Implement stopTransaction() method.
+    }
 }

--- a/src/Connections/Connection.php
+++ b/src/Connections/Connection.php
@@ -71,7 +71,7 @@ class Connection extends Collection implements ConnectionInterface
      *
      * @param $name
      * @param $args
-     * @return Graph
+     * @return \Spider\Drivers\Response
      */
     public function __call($name, $args)
     {
@@ -107,7 +107,8 @@ class Connection extends Collection implements ConnectionInterface
     }
 
     /**
-     * @param $driver
+     * Create a driver from classname
+     * @param string $driver
      */
     protected function driverFromString($driver)
     {
@@ -128,7 +129,7 @@ class Connection extends Collection implements ConnectionInterface
      * This is the R in CRUD
      *
      * @param CommandInterface|BaseBuilder $query
-     * @return Response
+     * @return \Spider\Drivers\Response
      */
     public function executeCommand($query)
     {
@@ -150,11 +151,11 @@ class Connection extends Collection implements ConnectionInterface
     /**
      * Opens a transaction
      *
-     * @return bool
+     * @return bool|null
      */
     public function startTransaction()
     {
-        // TODO: Implement startTransaction() method.
+        return $this->driver->startTransaction();
     }
 
     /**
@@ -162,10 +163,10 @@ class Connection extends Collection implements ConnectionInterface
      *
      * @param bool $commit whether this is a commit (true) or a rollback (false)
      *
-     * @return bool
+     * @return bool|null
      */
     public function stopTransaction($commit = true)
     {
-        // TODO: Implement stopTransaction() method.
+        return $this->driver->stopTransaction($commit);
     }
 }

--- a/src/Connections/ConnectionInterface.php
+++ b/src/Connections/ConnectionInterface.php
@@ -22,6 +22,40 @@ interface ConnectionInterface
     public function close();
 
     /**
+     * Executes a Command
+     *
+     * This is the R in CRUD
+     *
+     * @param CommandInterface|BaseBuilder $query
+     * @return Response
+     */
+    public function executeCommand($query);
+
+    /**
+     * Runs a Command without waiting for a response
+     *
+     * @param CommandInterface|BaseBuilder $command
+     * @return $this
+     */
+    public function runCommand($command);
+
+    /**
+     * Opens a transaction
+     *
+     * @return bool
+     */
+    public function startTransaction();
+
+    /**
+     * Closes a transaction
+     *
+     * @param bool $commit whether this is a commit (true) or a rollback (false)
+     *
+     * @return bool
+     */
+    public function stopTransaction($commit = true);
+
+    /**
      * Returns the class name of the active driver
      * @return string
      */

--- a/src/Connections/Manager.php
+++ b/src/Connections/Manager.php
@@ -39,7 +39,7 @@ class Manager extends Collection implements ManagesItemsInterface
      * Hand alias for stored Connection
      * Hand array for implicit Connection
      *
-     * @param string $alias alias | properties | default
+     * @param string|null $alias alias | properties | default
      * @return Connection
      * @throws \Spider\Exceptions\ConnectionNotFoundException
      */

--- a/src/Drivers/AbstractDriver.php
+++ b/src/Drivers/AbstractDriver.php
@@ -2,8 +2,11 @@
 namespace Spider\Drivers;
 
 use Spider\Base\Collection;
+use Spider\Commands\BaseBuilder;
+use Spider\Commands\Command;
 use Spider\Commands\Languages\ProcessorInterface;
 use Spider\Exceptions\NotSupportedException;
+use Symfony\Component\Config\Definition\Exception\Exception;
 
 abstract class AbstractDriver extends Collection implements DriverInterface
 {
@@ -66,5 +69,32 @@ abstract class AbstractDriver extends Collection implements DriverInterface
 
         $class = $this->languages[$language];
         return new $class;
+    }
+
+    /**
+     * Transforms a Builder to a Command if needed
+     * @param $command
+     * @param $language
+     * @return Command
+     * @throws NotSupportedException
+     * @throws \Exception
+     */
+    protected function ensureCommand($command, $language)
+    {
+        if ($command instanceof BaseBuilder) {
+            $processor = new $this->languages[$language];
+            $command = $command->getCommand($processor);
+            return $command;
+        }
+
+        if (!$command instanceof Command) {
+            throw new \Exception("Drivers only accept Commands or instances of BaseBuilder");
+        }
+
+        if (!$this->isSupportedLanguage($command->getScriptLanguage())) {
+            throw new NotSupportedException(__CLASS__ . " does not support " . $command->getScriptLanguage());
+        }
+
+        return $command;
     }
 }

--- a/src/Drivers/DriverInterface.php
+++ b/src/Drivers/DriverInterface.php
@@ -22,40 +22,22 @@ interface DriverInterface extends ManagesItemsInterface
     public function close();
 
     /**
-     * Executes a Query or read command
+     * Executes a Command
      *
      * This is the R in CRUD
      *
      * @param CommandInterface|BaseBuilder $query
      * @return Response
      */
-    public function executeReadCommand($query);
+    public function executeCommand($query);
 
     /**
-     * Executes a write command
-     *
-     * These are the "CUD" in CRUD
-     *
-     * @param CommandInterface|BaseBuilder $command
-     * @return Response
-     */
-    public function executeWriteCommand($command);
-
-    /**
-     * Executes a read command without waiting for a response
-     *
-     * @param CommandInterface|BaseBuilder $query
-     * @return $this
-     */
-    public function runReadCommand($query);
-
-    /**
-     * Executes a write command without waiting for a response
+     * Runs a Command without waiting for a response
      *
      * @param CommandInterface|BaseBuilder $command
      * @return $this
      */
-    public function runWriteCommand($command);
+    public function runCommand($command);
 
     /**
      * Opens a transaction

--- a/src/Drivers/Gremlin/Driver.php
+++ b/src/Drivers/Gremlin/Driver.php
@@ -93,7 +93,7 @@ class Driver extends AbstractDriver implements DriverInterface
      * @throws \Exception
      * @throws \brightzone\rexpro\ServerException
      */
-    public function executeReadCommand($query)
+    public function executeCommand($query)
     {
         if ($query instanceof BaseBuilder) {
             throw new NotSupportedException("There are currently no processors for gremlin/cypher.");
@@ -116,20 +116,6 @@ class Driver extends AbstractDriver implements DriverInterface
     }
 
     /**
-     * Executes a write command
-     *
-     * These are the "CUD" in CRUD
-     *
-     * @param CommandInterface|BaseBuilder $command
-     *
-     * @return Response
-     */
-    public function executeWriteCommand($command)
-    {
-        return $this->executeReadCommand($command);
-    }
-
-    /**
      * Executes a read command without waiting for a response
      *
      * @param CommandInterface|BaseBuilder $query
@@ -137,23 +123,10 @@ class Driver extends AbstractDriver implements DriverInterface
      * @throws \Exception
      * @throws \brightzone\rexpro\ServerException
      */
-    public function runReadCommand($query)
+    public function runCommand($query)
     {
-        $this->executeReadCommand($query);
+        $this->executeCommand($query);
         return $this;
-    }
-
-
-    /**
-     * Executes a write command without waiting for a response
-     *
-     * @param CommandInterface|BaseBuilder $command
-     *
-     * @return $this
-     */
-    public function runWriteCommand($command)
-    {
-        return $this->runReadCommand($command);
     }
 
     /**

--- a/src/Drivers/Neo4J/Driver.php
+++ b/src/Drivers/Neo4J/Driver.php
@@ -89,12 +89,15 @@ class Driver extends AbstractDriver implements DriverInterface
      */
     public function executeCommand($query)
     {
-        if ($query instanceof BaseBuilder) {
-            $processor = new $this->languages['cypher'];
-            $query = $query->getCommand($processor);
-        } elseif (!$this->isSupportedLanguage($query->getScriptLanguage())) {
-            throw new NotSupportedException(__CLASS__ . " does not support " . $query->getScriptLanguage());
-        }
+        // Generate command from a Builder
+        $query = $this->ensureCommand($query, 'cypher');
+
+//        if ($query instanceof BaseBuilder) {
+//            $processor = new $this->languages['cypher'];
+//            $query = $query->getCommand($processor);
+//        } elseif (!$this->isSupportedLanguage($query->getScriptLanguage())) {
+//            throw new NotSupportedException(__CLASS__ . " does not support " . $query->getScriptLanguage());
+//        }
 
         $neoQuery = new Query($this->client, $query->getScript());
         if ($this->inTransaction) {

--- a/src/Drivers/Neo4J/Driver.php
+++ b/src/Drivers/Neo4J/Driver.php
@@ -87,7 +87,7 @@ class Driver extends AbstractDriver implements DriverInterface
      * @throws NotSupportedException
      * @throws \Exception
      */
-    public function executeReadCommand($query)
+    public function executeCommand($query)
     {
         if ($query instanceof BaseBuilder) {
             $processor = new $this->languages['cypher'];
@@ -105,18 +105,6 @@ class Driver extends AbstractDriver implements DriverInterface
         return new Response(['_raw' => $response, '_driver' => $this]);
     }
 
-    /**
-     * Executes a write command
-     *
-     * These are the "CUD" in CRUD
-     *
-     * @param CommandInterface|BaseBuilder $command
-     * @return Response
-     */
-    public function executeWriteCommand($command)
-    {
-        return $this->executeReadCommand($command);
-    }
 
     /**
      * Executes a read command without waiting for a response
@@ -124,21 +112,10 @@ class Driver extends AbstractDriver implements DriverInterface
      * @param CommandInterface|BaseBuilder $query
      * @return Driver $this
      */
-    public function runReadCommand($query)
+    public function runCommand($query)
     {
-        $this->executeReadCommand($query);
+        $this->executeCommand($query);
         return $this;
-    }
-
-    /**
-     * Executes a write command without waiting for a response
-     *
-     * @param CommandInterface|BaseBuilder $command
-     * @return void
-     */
-    public function runWriteCommand($command)
-    {
-        $this->executeWriteCommand($command);
     }
 
     /**

--- a/src/Drivers/Neo4J/Driver.php
+++ b/src/Drivers/Neo4J/Driver.php
@@ -92,13 +92,6 @@ class Driver extends AbstractDriver implements DriverInterface
         // Generate command from a Builder
         $query = $this->ensureCommand($query, 'cypher');
 
-//        if ($query instanceof BaseBuilder) {
-//            $processor = new $this->languages['cypher'];
-//            $query = $query->getCommand($processor);
-//        } elseif (!$this->isSupportedLanguage($query->getScriptLanguage())) {
-//            throw new NotSupportedException(__CLASS__ . " does not support " . $query->getScriptLanguage());
-//        }
-
         $neoQuery = new Query($this->client, $query->getScript());
         if ($this->inTransaction) {
             $response = $this->transaction->addStatements($neoQuery);

--- a/src/Drivers/OrientDB/Driver.php
+++ b/src/Drivers/OrientDB/Driver.php
@@ -207,12 +207,7 @@ class Driver extends AbstractDriver implements DriverInterface
     protected function dispatchCommand($command)
     {
         // Generate command from a Builder
-        if ($command instanceof BaseBuilder) {
-            $processor = new $this->languages['orientSQL'];
-            $command = $command->getCommand($processor);
-        } elseif (!$this->isSupportedLanguage($command->getScriptLanguage())) {
-            throw new NotSupportedException(__CLASS__ . " does not support " . $command->getScriptLanguage());
-        }
+        $command = $this->ensureCommand($command, 'orientSQL');
 
         // Ensure Command's Script is a SqlBatch
         if (!$this->isBatch($command->getScript())) {

--- a/src/Drivers/OrientDB/Driver.php
+++ b/src/Drivers/OrientDB/Driver.php
@@ -1,7 +1,6 @@
 <?php
 namespace Spider\Drivers\OrientDB;
 
-use Michaels\Manager\Contracts\ManagesItemsInterface;
 use PhpOrient\Exceptions\PhpOrientException as ServerException;
 use PhpOrient\PhpOrient;
 use PhpOrient\Protocols\Binary\Data\Record as OrientRecord;
@@ -198,7 +197,7 @@ class Driver extends AbstractDriver implements DriverInterface
      * These are the "CUD" in CRUD
      *
      * @param CommandInterface|BaseBuilder $command
-     * @return mixed|Response Either Response or raw values for some commands
+     * @return Response Either Response or raw values for some commands
      * @throws ClassDoesNotExistException
      * @throws NotSupportedException
      * @throws ServerException
@@ -329,7 +328,7 @@ class Driver extends AbstractDriver implements DriverInterface
     /* Internals */
     /**
      * Checks to see if a sql script is a batch
-     * @param $script
+     * @param string $script
      * @return bool
      */
     protected function isBatch($script)

--- a/src/Drivers/OrientDB/Driver.php
+++ b/src/Drivers/OrientDB/Driver.php
@@ -49,8 +49,8 @@ class Driver extends AbstractDriver implements DriverInterface
     /** @var string Messge for exception thrown at formatting error */
     protected $formatMessage = "The response from the database was incorrectly formatted for this operation";
 
-    /** @var string Current transaction (batch) statement */
-    protected $transaction = '';
+    /** @var SqlBatch Current transaction (batch) statement */
+    protected $transaction;
 
     /**
      * @var array The supported languages and their processors
@@ -127,7 +127,7 @@ class Driver extends AbstractDriver implements DriverInterface
      * Closes a transaction
      *
      * @param bool $commit whether this is a commit (TRUE) or a rollback (FALSE)
-     * @return Response
+     * @return Response|null
      * @throws \Exception
      */
     public function stopTransaction($commit = true)
@@ -167,7 +167,7 @@ class Driver extends AbstractDriver implements DriverInterface
      * This is the R in CRUD
      *
      * @param CommandInterface|\Spider\Commands\BaseBuilder $command
-     * @return Response
+     * @return Response|null
      */
     public function executeCommand($command)
     {
@@ -198,7 +198,7 @@ class Driver extends AbstractDriver implements DriverInterface
      * These are the "CUD" in CRUD
      *
      * @param CommandInterface|BaseBuilder $command
-     * @return mixed|Response Either Response or raw values for some commands
+     * @return mixed Either Response or raw values for some commands
      * @throws ClassDoesNotExistException
      * @throws NotSupportedException
      * @throws ServerException

--- a/tests/Stubs/DriverStub.php
+++ b/tests/Stubs/DriverStub.php
@@ -67,22 +67,9 @@ class DriverStub extends AbstractDriver implements DriverInterface
      * @param CommandInterface|BaseBuilder $query
      * @return array|Record|Graph
      */
-    public function executeReadCommand($query)
+    public function executeCommand($query)
     {
         return new Response(['_raw' => '', '_driver' => $this]);
-    }
-
-    /**
-     * Executes a write command
-     *
-     * These are the "CUD" in CRUD
-     *
-     * @param CommandInterface|BaseBuilder $command
-     * @return Graph|Record|array|mixed mixed values for some write commands
-     */
-    public function executeWriteCommand($command)
-    {
-        return $this->executeReadCommand($command);
     }
 
     /**
@@ -91,24 +78,14 @@ class DriverStub extends AbstractDriver implements DriverInterface
      * @param CommandInterface|BaseBuilder $query
      * @return $this
      */
-    public function runReadCommand($query)
+    public function runCommand($query)
     {
-        $this->executeReadCommand($query);
+        $this->executeCommand($query);
         return $this;
     }
 
+
     /**
-     * Executes a write command without waiting for a response
-     *
-     * @param CommandInterface|BaseBuilder $command
-     * @return $this
-     */
-    public function runWriteCommand($command)
-    {
-        $this->executeWriteCommand($command);
-        return $this;
-    }
-        /**
      * Opens a transaction
      *
      * @return bool

--- a/tests/Unit/Drivers/BaseTestSuite.php
+++ b/tests/Unit/Drivers/BaseTestSuite.php
@@ -293,7 +293,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             );
 
             // Clean up
-            $driver->runWriteCommand(
+            $driver->runCommand(
                 $this->getCommand(
                     'delete-one-item',
                     'testVertex'

--- a/tests/Unit/Drivers/BaseTestSuite.php
+++ b/tests/Unit/Drivers/BaseTestSuite.php
@@ -145,7 +145,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $driver = $this->driver();
             $driver->open();
 
-            $response = $driver->executeReadCommand($this->getCommand('select-one-item'));
+            $response = $driver->executeCommand($this->getCommand('select-one-item'));
 
             $driver->close();
 
@@ -170,7 +170,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $driver = $this->driver();
             $driver->open();
 
-            $response = $driver->executeReadCommand($this->getCommand('select-two-items'));
+            $response = $driver->executeCommand($this->getCommand('select-two-items'));
 
             $driver->close();
 
@@ -194,7 +194,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         $driver->open();
 
         // Create new
-        $response = $driver->executeWriteCommand($this->getCommand('create-one-item'));
+        $response = $driver->executeCommand($this->getCommand('create-one-item'));
 
         $this->assertInstanceOf('Spider\Drivers\Response', $response, 'failed to return a Response Object');
         $newRecord = $response->getSet();
@@ -207,7 +207,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         );
 
         // Update existing
-        $response = $driver->executeWriteCommand($this->getCommand('update-one-item', $newRecord->name));
+        $response = $driver->executeCommand($this->getCommand('update-one-item', $newRecord->name));
 
         $this->assertInstanceOf('Spider\Drivers\Response', $response, 'failed to return a Response Object');
         $updatedRecord = $response->getSet();
@@ -220,7 +220,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         );
 
         // Delete That one
-        $response = $driver->executeWriteCommand($this->getCommand('delete-one-item', $updatedRecord->name));
+        $response = $driver->executeCommand($this->getCommand('delete-one-item', $updatedRecord->name));
 
         $this->assertInstanceOf('Spider\Drivers\Response', $response, 'failed to return a Response Object');
         $deletedRecord = $response->getSet();
@@ -228,7 +228,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $deletedRecord, "failed to delete");
 
         // And try to get it again
-        $response = $driver->executeReadCommand(
+        $response = $driver->executeCommand(
             $this->getCommand('select-by-name', $updatedRecord->name)
         );
 
@@ -249,12 +249,12 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $driver->open();
             $driver->startTransaction();
 
-            $driver->executeWriteCommand($this->getCommand('create-one-item'));
+            $driver->executeCommand($this->getCommand('create-one-item'));
 
             $driver->stopTransaction(false);
 
             // Try to get that non-existent vertex
-            $response = $driver->executeReadCommand(
+            $response = $driver->executeCommand(
                 $this->getCommand(
                     'select-by-name',
                     'testVertex'
@@ -273,12 +273,12 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $driver->open();
             $driver->startTransaction();
 
-            $driver->executeWriteCommand($this->getCommand('create-one-item'));
+            $driver->executeCommand($this->getCommand('create-one-item'));
 
             $driver->stopTransaction(true);
 
             // Get the item just created
-            $response = $driver->executeReadCommand(
+            $response = $driver->executeCommand(
                 $this->getCommand(
                     'select-by-name',
                     'testVertex'
@@ -375,7 +375,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $driver = $this->driver();
             $driver->open();
 
-            $rawResponse = $driver->executeReadCommand(
+            $rawResponse = $driver->executeCommand(
                 $this->getCommand('select-one-item')
             )->getRaw();
 
@@ -400,7 +400,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
             $driver = $this->driver();
             $driver->open();
 
-            $rawResponse = $driver->executeReadCommand(
+            $rawResponse = $driver->executeCommand(
                 $this->getCommand('select-two-items')
             )->getRaw();
 
@@ -446,7 +446,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         $this->specify("it throws an Exception when a modifying protected id", function () {
             $driver = $this->driver();
             $driver->open();
-            $response = $driver->executeReadCommand($this->getCommand('select-one-item'));
+            $response = $driver->executeCommand($this->getCommand('select-one-item'));
             $consistent = $response->getSet();
 
             $this->assertEquals(
@@ -462,7 +462,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         $this->specify("it throws an Exception when a modifying protected label", function () {
             $driver = $this->driver();
             $driver->open();
-            $response = $driver->executeReadCommand($this->getCommand('select-one-item'));
+            $response = $driver->executeCommand($this->getCommand('select-one-item'));
             $consistent = $response->getSet();
 
             $this->assertEquals(
@@ -479,7 +479,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         $this->specify("it throws an Exception when a modifying protected meta", function () {
             $driver = $this->driver();
             $driver->open();
-            $response = $driver->executeReadCommand($this->getCommand('select-one-item'));
+            $response = $driver->executeCommand($this->getCommand('select-one-item'));
             $consistent = $response->getSet();
 
             $this->assertEquals(
@@ -500,7 +500,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         $this->specify("it throws an Exception when a command with an unknown language is submitted", function () {
             $driver = $this->driver();
             $driver->open();
-            $response = $driver->executeReadCommand(new Command('script', 'unknown-language'));
+            $response = $driver->executeCommand(new Command('script', 'unknown-language'));
         }, ['throws' => new NotSupportedException]);
     }
 
@@ -512,7 +512,7 @@ abstract class BaseTestSuite extends \PHPUnit_Framework_TestCase
         $driver->open();
         $command = $this->getCommand('select-one-item');
         $command->setScript('incorrect-script');
-        $response = $driver->executeReadCommand($command);
+        $response = $driver->executeCommand($command);
     }
 
     /* Internal Methods */

--- a/tests/Unit/Drivers/Neo4J/DriverTest.php
+++ b/tests/Unit/Drivers/Neo4J/DriverTest.php
@@ -151,7 +151,7 @@ class DriverTest extends BaseTestSuite
     {
         $driver = $this->driver();
         $driver->open();
-        $response = $driver->executeReadCommand(new Command(
+        $response = $driver->executeCommand(new Command(
             "MATCH p =((a)-[:created]->(b)<-[:created]-(c))
              RETURN p
              ORDER BY a.name ASC, c.name DESC
@@ -173,7 +173,7 @@ class DriverTest extends BaseTestSuite
         //$this->assertEquals(2, $consistent[0][2]->meta()->id, "id wasn't properly populated");
         $this->assertEquals('person', $consistent[0][2]->meta()->label, "label wasn't properly populated");
         $this->assertEquals('peter', $consistent[0][2]->name, "name wasn't properly populated");
-        $response = $driver->executeReadCommand(new Command(
+        $response = $driver->executeCommand(new Command(
             "MATCH p =((a)-[:created]->(b)<-[:created]-(c))
              RETURN p
              ORDER BY a.name ASC, c.name DESC

--- a/tests/Unit/Drivers/OrientDB/DriverTest.php
+++ b/tests/Unit/Drivers/OrientDB/DriverTest.php
@@ -144,17 +144,17 @@ class DriverTest extends BaseTestSuite
             $driver->open();
             $driver->startTransaction();
 
-            $driver->executeWriteCommand(new Command(
+            $driver->executeCommand(new Command(
                 "CREATE VERTEX CONTENT {name:'one'}", "orientSQL"
             ));
 
-            $driver->executeWriteCommand(new Command(
+            $driver->executeCommand(new Command(
                 "CREATE VERTEX CONTENT {name:'two'}", "orientSQL"
-            ), "orientSQL");
+            ));
 
-            $driver->executeWriteCommand(new Command(
+            $driver->executeCommand(new Command(
                 "CREATE VERTEX CONTENT {name:'three'}", "orientSQL"
-            ), "orientSQL");
+            ));
 
             $expected = "begin\n";
             $expected .= "LET t1 = CREATE VERTEX CONTENT {name:'one'}\n";
@@ -163,9 +163,9 @@ class DriverTest extends BaseTestSuite
             $expected .= "commit retry 100\n";
             $expected .= 'return [$t1,$t2,$t3]';
 
-            $driver->stopTransaction(false); // false
-
             $actual = $driver->getTransactionForTest();
+
+            $driver->stopTransaction(false); // false
 
             $this->assertEquals($expected, $actual, "the transaction statement was incorrectly built");
             $driver->close();
@@ -178,7 +178,7 @@ class DriverTest extends BaseTestSuite
             $driver = $this->driver();
             $driver->open();
 
-            $driver->executeWriteCommand(new Command(
+            $driver->executeCommand(new Command(
                 "INSERT INTO nothing CONTENT {name: 'michael'}",
                 "orientSQL"
             ));
@@ -193,7 +193,7 @@ class DriverTest extends BaseTestSuite
             $driver = $this->driver();
             $driver->open();
 
-            $response = $driver->executeReadCommand(new Command(
+            $response = $driver->executeCommand(new Command(
                 "SELECT name FROM V LIMIT 1", 'orientSQL',
                 "orientSQL"
             ));
@@ -210,7 +210,7 @@ class DriverTest extends BaseTestSuite
             $driver = $this->driver();
             $driver->open();
 
-            $response = $driver->executeReadCommand(new Command(
+            $response = $driver->executeCommand(new Command(
                 "SELECT FROM V LIMIT 1", 'orientSQL',
                 "orientSQL"
             ));
@@ -223,7 +223,7 @@ class DriverTest extends BaseTestSuite
             $driver = $this->driver();
             $driver->open();
 
-            $response = $driver->executeReadCommand(new Command(
+            $response = $driver->executeCommand(new Command(
                 "SELECT name FROM V", 'orientSQL',
                 "orientSQL"
             ));
@@ -251,7 +251,7 @@ class DriverTest extends BaseTestSuite
         $driver = $this->driver();
         $driver->open();
 
-        $response = $driver->executeReadCommand($builder);
+        $response = $driver->executeCommand($builder);
 
         $consistent = $response->getSet();
         $this->assertEquals(6, count($consistent), "wrong number of elements found");


### PR DESCRIPTION
From Issue #78 this refactors the `DriverInterface` and all the drivers.

Removes `executeReadCommand()`, `executeWriteCommand()`, `runReadCommand()`, `runWriteCommand()` and replaces them with `runCommand()` and `executeCommand()`

This pr also moves the logic for passing a builder to the driver into `AbstractDriver` from the Neo4j and Orient drivers. It introduces `ensureCommand($command, $scriptLanguage)` which will proccess a builder, make sure the language is supported, and pass back a command. If a command is handed, it simply returns the command.
