### PR TITLE
Multiple CRUD operations per query

### DIFF
--- a/src/Commands/Bag.php
+++ b/src/Commands/Bag.php
@@ -114,4 +114,7 @@ class Bag extends Object
     const ELEMENT_EDGE   = 510;
     const ELEMENT_LABEL  = 520;
     const ELEMENT_ID     = 530;
+    const ELEMENT_TYPE = 540;
+    const EDGE_INV = 550;
+    const EDGE_OUTV = 560;
 }

--- a/src/Commands/Bag.php
+++ b/src/Commands/Bag.php
@@ -42,9 +42,6 @@ class Bag extends Object
     /** @var array Data to be inserted/updated */
     public $data = [];
 
-    /** @var int How many records to create */
-    public $createCount = 0;
-
     /**
      * What do you want after an operation is complete?
      *

--- a/src/Commands/BaseBuilder.php
+++ b/src/Commands/BaseBuilder.php
@@ -158,17 +158,6 @@ class BaseBuilder
 
     /* Fluent methods for building queries */
     /**
-     * Set the type of the target in the current Command Bag
-     * @param $type
-     * @return $this
-     */
-    public function type($type)
-    {
-        $this->addToCurrentBag('target', $type);
-        return $this;
-    }
-
-    /**
      * Add data to the current command bag (for insert and update)
      * @param $property
      * @param null $value

--- a/src/Commands/BaseBuilder.php
+++ b/src/Commands/BaseBuilder.php
@@ -10,7 +10,7 @@ use Spider\Commands\Languages\ProcessorInterface;
  */
 class BaseBuilder
 {
-    /** @var Bag The CommandBag with command parameters */
+    /** @var array An array of CommandBags with command parameters */
     protected $bag;
 
     /** @var  ProcessorInterface The current language processor */
@@ -24,33 +24,27 @@ class BaseBuilder
      * With an optional language processor
      *
      * @param ProcessorInterface|null $processor
-     * @param Bag|null $bag
+     * @param array|null $bag
      */
     public function __construct(
         ProcessorInterface $processor = null,
-        Bag $bag = null
+        array $bag = null
     ) {
         $this->processor = $processor;
-        $this->bag = $bag ?: new Bag();
+        $this->bag = $bag ?: [];
     }
 
-    /* Fluent Methods for building queries */
+    /* Internal methods for building queries */
     /**
      * Add an `insert` clause to the current command bag
      * @param array $data
      * @return BaseBuilder
      */
-    public function insert(array $data)
+    public function internalCreate(array $data)
     {
-        $this->bag->command = Bag::COMMAND_CREATE;
-
-        if (isset($data[0]) && is_array($data[0])) {
-            $this->bag->createCount = count($data);
-        } else {
-            $this->bag->createCount = 1;
-        }
-
-        $this->bag->data += $data;
+        $this->addNewBag();
+        $this->addToCurrentBag('command', Bag::COMMAND_CREATE);
+        $this->addToCurrentBag('data', $data);
 
         return $this;
     }
@@ -61,10 +55,11 @@ class BaseBuilder
      * @param null $projections Specific fields to retrieve (defaults to *)
      * @return $this
      */
-    public function retrieve($projections = null)
+    public function internalRetrieve($projections = null)
     {
-        $this->bag->command = Bag::COMMAND_RETRIEVE;
-        $this->projections($projections);
+        $this->addNewBag();
+        $this->addToCurrentBag('command', Bag::COMMAND_RETRIEVE);
+        $this->internalProjections($projections);
         return $this;
     }
 
@@ -73,15 +68,17 @@ class BaseBuilder
      * @param array|null $properties should be in the format [props=>values, props2=>values2, ...]
      * @return $this
      */
-    public function update($properties = null)
+    public function internalUpdate($properties = null)
     {
-        $this->bag->command = Bag::COMMAND_UPDATE;
+        $this->addNewBag();
+        $this->addToCurrentBag('command', Bag::COMMAND_UPDATE);
 
         if (is_null($properties)) {
             return $this;
         }
 
         $this->data($properties);
+
         return $this;
     }
 
@@ -89,36 +86,10 @@ class BaseBuilder
      * Add a `delete` clause to the current command bag
      * @return BaseBuilder
      */
-    public function delete()
+    public function internalDelete()
     {
-        $this->bag->command = Bag::COMMAND_DELETE;
-        return $this;
-    }
-
-    /**
-     * Add data to the current command bag (for insert and update)
-     * @param $property
-     * @param null $value
-     * @return $this
-     */
-    public function data($property, $value = null)
-    {
-        if (!is_array($property)) {
-            return $this->data([$property => $value]);
-        } else {
-            $this->bag->data[] = $property;
-            return $this;
-        }
-    }
-
-    /**
-     * Set the type of the target in the current Command Bag
-     * @param $type
-     * @return $this
-     */
-    public function type($type)
-    {
-        $this->bag->target = $type;
+        $this->addNewBag();
+        $this->addToCurrentBag('command', Bag::COMMAND_DELETE);
         return $this;
     }
 
@@ -131,10 +102,10 @@ class BaseBuilder
      * @param $projections
      * @return $this
      */
-    public function projections($projections)
+    public function internalProjections($projections)
     {
         if (is_null($projections)) {
-            $this->bag->projections = [];
+            $this->addToCurrentBag('projections', []);
             return $this;
         }
 
@@ -143,7 +114,7 @@ class BaseBuilder
             throw new InvalidArgumentException("Projections must be a comma-separated string or an array");
         }
 
-        $this->bag->projections = $this->csvToArray($projections);
+        $this->addToCurrentBag('projections', $this->csvToArray($projections));
         return $this;
     }
 
@@ -180,9 +151,39 @@ class BaseBuilder
             }
         }
 
-        $this->bag->where = array_merge($this->bag->where, $constraints);
+        $this->addToCurrentBag('where', array_merge($this->getFromCurrentBag('where'), $constraints));
 
         return $this;
+    }
+
+    /* Fluent methods for building queries */
+    /**
+     * Set the type of the target in the current Command Bag
+     * @param $type
+     * @return $this
+     */
+    public function type($type)
+    {
+        $this->addToCurrentBag('target', $type);
+        return $this;
+    }
+
+    /**
+     * Add data to the current command bag (for insert and update)
+     * @param $property
+     * @param null $value
+     * @return $this
+     */
+    public function data($property, $value = null)
+    {
+        if (!is_array($property)) {
+            return $this->data([$property => $value]);
+        } else {
+            $newData = $this->getFromCurrentBag('data');
+            $newData[] = $property;
+            $this->addToCurrentBag('data', $newData);
+            return $this;
+        }
     }
 
     /**
@@ -192,7 +193,7 @@ class BaseBuilder
      */
     public function limit($limit)
     {
-        $this->bag->limit = $limit;
+        $this->addToCurrentBag('limit', $limit);
         return $this;
     }
 
@@ -204,7 +205,7 @@ class BaseBuilder
     public function groupBy($fields)
     {
         $fields = $this->csvToArray($fields);
-        $this->bag->groupBy = $fields;
+        $this->addToCurrentBag('groupBy', $fields);
         return $this;
     }
 
@@ -216,7 +217,7 @@ class BaseBuilder
      */
     public function orderBy($field, $direction = Bag::ORDER_ASC)
     {
-        $this->bag->orderBy[] = [$field, $direction];
+        $this->addToCurrentBag('orderBy', [[$field, $direction]]);
         return $this;
     }
 
@@ -224,9 +225,9 @@ class BaseBuilder
      * Flag the desired response as `tree`
      * @return $this
      */
-    public function tree()
+    public function setAsTree()
     {
-        $this->bag->map = Bag::MAP_TREE;
+        $this->addToCurrentBag('map', Bag::MAP_TREE);
         return $this;
     }
 
@@ -234,10 +235,33 @@ class BaseBuilder
      * Flag the desired response as `path`
      * @return $this
      */
-    public function path()
+    public function setAsPath()
     {
-        $this->bag->map = Bag::MAP_PATH;
+        $this->addToCurrentBag('map', Bag::MAP_PATH);
         return $this;
+    }
+
+    /* Sub Queries */
+    /**
+     * Sets an alias for the current command bag
+     * @param $alias
+     */
+    function set($alias)
+    {
+        $keys = array_keys($this->bag);
+        $index = end($keys);
+        $this->bag[$alias] = $this->getCurrentBag();
+        unset($this->bag[$index]);
+    }
+
+    /**
+     * Returns a Command Bag by alias
+     * @param $alias
+     * @return mixed
+     */
+    function get($alias)
+    {
+        return $this->bag[$alias];
     }
 
     /* Manage the Builder itself */
@@ -247,7 +271,10 @@ class BaseBuilder
      */
     public function clear($properties = [])
     {
-        $this->bag = new Bag($properties);
+        $this->bag = [];
+        if (!empty($properties)) {
+            $this->bag[] = new Bag($properties);
+        }
     }
 
     /**
@@ -331,5 +358,44 @@ class BaseBuilder
         }
 
         return $string;
+    }
+
+    /**
+     * Adds a clause to the current Command Bag
+     * @param $property
+     * @param $value
+     */
+    protected function addToCurrentBag($property, $value)
+    {
+
+        if (! end($this->bag) instanceof Bag) {
+            $this->addNewBag();
+        }
+
+        $this->getCurrentBag()->$property = $value;
+    }
+
+    protected function getCurrentBag()
+    {
+        return end($this->bag);
+    }
+
+    /**
+     * Get's a property from the current Command Bag
+     * @param $property
+     * @return mixed
+     */
+    protected function getFromCurrentBag($property)
+    {
+        return $this->getCurrentBag()->$property;
+    }
+
+    /**
+     * Adds a new CommandBag for the beginning of a new operation.
+     * @param null $alias
+     */
+    protected function addNewBag($alias = null)
+    {
+        $this->bag[] = new Bag();
     }
 }

--- a/src/Commands/Builder.php
+++ b/src/Commands/Builder.php
@@ -144,6 +144,17 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Set the type of the target in the current Command Bag
+     * @param $type
+     * @return $this
+     */
+    public function type($type)
+    {
+        $this->addToCurrentBag('target', $type);
+        return $this;
+    }
+
+    /**
      * Alias of `data()`
      * @param $property
      * @param null $value

--- a/tests/Unit/Commands/Builders/BaseBuilder/BaseTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/BaseTest.php
@@ -10,20 +10,23 @@ class BaseTest extends TestSetup
     use Specify;
 
     /* Manage the Command Bag */
-    public function testCreateBag()
-    {
-        $this->assertEquals(new Bag(), $this->builder->getBag(), "failed to return an empty bag");
-    }
-
     public function testClearBag()
     {
         $this->builder
-            ->retrieve()
-            ->type(Bag::ELEMENT_VERTEX);
+            ->internalRetrieve();
 
         $this->builder->clear();
 
-        $this->assertEquals(new Bag(), $this->builder->getBag(), "failed to return an empty bag");
+        $this->assertEquals([], $this->builder->getBag(), "failed to return an empty bag");
+    }
+
+    public function testEnsureBagExists()
+    {
+        $this->builder->internalProjections('a');
+
+        $this->assertTrue(is_array($this->builder->getBag()), "failed to return an array of bags");
+        $this->assertCount(1, $this->builder->getBag(), "failed to return an array of one bag");
+        $this->assertInstanceOf('Spider\Commands\Bag', $this->builder->getBag()[0], "failed to return a Command Bag");
     }
 
     /* Projections tests */
@@ -32,9 +35,11 @@ class BaseTest extends TestSetup
     {
         $this->specify("it returns nothing by default", function () {
             $actual = $this->builder
+                ->internalRetrieve()
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
+                'command' => Bag::COMMAND_RETRIEVE,
                 'projections' => []
             ]);
 
@@ -43,7 +48,7 @@ class BaseTest extends TestSetup
 
         $this->specify("it returns a single value", function () {
             $actual = $this->builder
-                ->projections('username')
+                ->internalProjections('username')
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
@@ -55,7 +60,7 @@ class BaseTest extends TestSetup
 
         $this->specify("it several properties from array", function () {
             $actual = $this->builder
-                ->projections(['username', 'password'])
+                ->internalProjections(['username', 'password'])
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
@@ -67,7 +72,7 @@ class BaseTest extends TestSetup
 
         $this->specify("it several properties from csv string (one space)", function () {
             $actual = $this->builder
-                ->projections('username, password')
+                ->internalProjections('username, password')
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
@@ -79,7 +84,7 @@ class BaseTest extends TestSetup
 
         $this->specify("it returns several properties from csv string (no spaces)", function () {
             $actual = $this->builder
-                ->projections('username,password')
+                ->internalProjections('username,password')
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
@@ -91,7 +96,7 @@ class BaseTest extends TestSetup
 
         $this->specify("it returns several properties from csv string (many spaces)", function () {
             $actual = $this->builder
-                ->projections('username,           password')
+                ->internalProjections('username,           password')
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
@@ -103,12 +108,126 @@ class BaseTest extends TestSetup
 
         $this->specify("it throws exception if projections is not array or string", function () {
             $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
-                ->projections(3)
+                ->internalRetrieve()
+                ->internalProjections(3)
                 ->getBag();
 
         }, ['throws' => new \InvalidArgumentException("Projections must be a comma-separated string or an array")]);
+    }
 
+    public function testMultipleOperations()
+    {
+        $this->specify("it adds multiple operations in order", function() {
+            $this->builder->internalRetrieve('a');
+            $this->builder->internalWhere(['one', Bag::COMPARATOR_EQUAL, 'one', Bag::CONJUNCTION_AND]);
+
+            $this->builder->internalCreate([
+                'a' => 'A',
+                'b' => 'B'
+            ]);
+
+            $this->builder->internalUpdate([
+                'c' => 'C',
+                'd' => 'D'
+            ]);
+
+            $this->builder->internalDelete();
+            $actual = $this->builder->getBag();
+
+            $expected = $this->buildExpectedBags([
+                [
+                    'command' => Bag::COMMAND_RETRIEVE,
+                    'projections' => ['a'],
+                    'where' => [['one', Bag::COMPARATOR_EQUAL, 'one', Bag::CONJUNCTION_AND]],
+                ],
+                [
+                    'command' => Bag::COMMAND_CREATE,
+                    'data' => [
+                        'a' => 'A',
+                        'b' => 'B'
+                    ]
+                ],
+                [
+                    'command' => Bag::COMMAND_UPDATE,
+                    'data' => [
+                        'c' => 'C',
+                        'd' => 'D'
+                    ]
+                ],
+                [
+                    'command' => Bag::COMMAND_DELETE,
+                ]
+            ]);
+
+            $this->assertCount(4, $actual, "failed to return four command bags");
+            $this->assertEquals($expected, $actual, "failed to return several command bags");
+        });
+    }
+
+    public function testAliasing()
+    {
+        $this->specify("it sets and gets operations based on aliases", function() {
+            $this->builder->internalRetrieve('a');
+            $this->builder->internalWhere(['one', Bag::COMPARATOR_EQUAL, 'one', Bag::CONJUNCTION_AND]);
+            $this->builder->set('first');
+            $this->builder->set('third');
+
+            $this->builder->internalCreate([
+                'a' => 'A',
+                'b' => 'B'
+            ]);
+
+            $this->builder->internalUpdate([
+                'c' => 'C',
+                'd' => 'D'
+            ]);
+            $this->builder->set('second');
+
+            $this->builder->internalDelete();
+            $actual = $this->builder->getBag();
+
+            // Check the Bag
+            $this->assertTrue(is_array($actual), "failed to return an array");
+            $this->assertCount(4, $actual, "failed to return four command bags");
+
+            // Check the Keys
+            $keys = array_keys($actual);
+            $this->assertEquals(['third', 1, 'second', 3], $keys, "failed to return the correct aliases");
+
+            // Check the individual Bags
+            $expected = $this->buildExpectedBags([
+                [
+                    'command' => Bag::COMMAND_RETRIEVE,
+                    'projections' => ['a'],
+                    'where' => [['one', Bag::COMPARATOR_EQUAL, 'one', Bag::CONJUNCTION_AND]],
+                ],
+                [
+                    'command' => Bag::COMMAND_CREATE,
+                    'data' => [
+                        'a' => 'A',
+                        'b' => 'B'
+                    ]
+                ],
+                [
+                    'command' => Bag::COMMAND_UPDATE,
+                    'data' => [
+                        'c' => 'C',
+                        'd' => 'D'
+                    ]
+                ],
+                [
+                    'command' => Bag::COMMAND_DELETE,
+                ]
+            ]);
+
+            $i = 0;
+            foreach ($actual as $bag) {
+                $this->assertEquals($expected[$i], $bag, "failed to return the correct bag for index: $i");
+                $i++;
+            }
+
+            // Check getting by alias
+            $this->assertEquals($expected[2], $this->builder->get('second'), "failed to get correct bag");
+        });
     }
 }

--- a/tests/Unit/Commands/Builders/BaseBuilder/CreateTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/CreateTest.php
@@ -24,7 +24,6 @@ class CreateTest extends TestSetup
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_CREATE,
-                'target'=> Bag::ELEMENT_VERTEX,
                 'data' => $record
             ]);
 
@@ -44,32 +43,34 @@ class CreateTest extends TestSetup
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_CREATE,
                 'data' => $records,
-                'target'=> Bag::ELEMENT_VERTEX,
             ]);
 
             $this->assertEquals($expected, $actual, "failed to return correct command bag");
         });
     }
 
-    public function testCreateEdges()
+    public function testCreateVerticesAndEdges()
     {
-        $this->specify("it inserts a single edge", function () {
-            $record = [
-                'first' => 'first-value',
-                'second' => 'second-value',
-                'inV' => 'a',
-                'outV' => 'b',
+        $this->specify("it inserts a two vertices and an edge", function () {
+            $records = [
+                [Bag::ELEMENT_TYPE => Bag::ELEMENT_VERTEX, Bag::ELEMENT_LABEL => 'person', "name" => 'what'],
+                [Bag::ELEMENT_TYPE => Bag::ELEMENT_VERTEX, Bag::ELEMENT_LABEL => 'person', "name" => 'ever'],
+                [
+                    Bag::ELEMENT_TYPE => Bag::ELEMENT_VERTEX,
+                    Bag::ELEMENT_LABEL => 'label',
+                    Bag::EDGE_INV => 'a',
+                    Bag::EDGE_OUTV => 'b',
+                ]
+
             ];
 
             $actual = $this->builder
-                ->internalCreate($record)
-                ->type(Bag::ELEMENT_EDGE)
+                ->internalCreate($records)
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_CREATE,
-                'target' => Bag::ELEMENT_EDGE,
-                'data' => $record
+                'data' => $records
             ]);
 
             $this->assertEquals($expected, $actual, "failed to return correct command bag");

--- a/tests/Unit/Commands/Builders/BaseBuilder/CreateTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/CreateTest.php
@@ -19,15 +19,13 @@ class CreateTest extends TestSetup
             ];
 
             $actual = $this->builder
-                ->type(Bag::ELEMENT_VERTEX)
-                ->insert($record)
+                ->internalCreate($record)
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_CREATE,
-                'target' => Bag::ELEMENT_VERTEX,
-                'data' => $record,
-                'createCount' => 1
+                'target'=> Bag::ELEMENT_VERTEX,
+                'data' => $record
             ]);
 
             $this->assertEquals($expected, $actual, "failed to return correct command bag");
@@ -40,15 +38,38 @@ class CreateTest extends TestSetup
             ];
 
             $actual = $this->builder
-                ->type(Bag::ELEMENT_VERTEX)
-                ->insert($records)
+                ->internalCreate($records)
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_CREATE,
-                'target' => Bag::ELEMENT_VERTEX,
                 'data' => $records,
-                'createCount' => 2
+                'target'=> Bag::ELEMENT_VERTEX,
+            ]);
+
+            $this->assertEquals($expected, $actual, "failed to return correct command bag");
+        });
+    }
+
+    public function testCreateEdges()
+    {
+        $this->specify("it inserts a single edge", function () {
+            $record = [
+                'first' => 'first-value',
+                'second' => 'second-value',
+                'inV' => 'a',
+                'outV' => 'b',
+            ];
+
+            $actual = $this->builder
+                ->internalCreate($record)
+                ->type(Bag::ELEMENT_EDGE)
+                ->getBag();
+
+            $expected = $this->buildExpectedBag([
+                'command' => Bag::COMMAND_CREATE,
+                'target' => Bag::ELEMENT_EDGE,
+                'data' => $record
             ]);
 
             $this->assertEquals($expected, $actual, "failed to return correct command bag");

--- a/tests/Unit/Commands/Builders/BaseBuilder/DeleteTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/DeleteTest.php
@@ -13,11 +13,19 @@ class DeleteTest extends TestSetup
     {
         $this->specify("it drops a single record dispatching from `delete()`", function () {
             $actual = $this->builder
-                ->delete()
+                ->internalRetrieve()
+                ->internalWhere(['name', Bag::COMPARATOR_EQUAL, 'test-name', Bag::CONJUNCTION_AND])
+                ->internalDelete()
                 ->getBag();
 
-            $expected = $this->buildExpectedBag([
-                'command' => Bag::COMMAND_DELETE
+            $expected = $this->buildExpectedBags([
+                [
+                    'command' => Bag::COMMAND_RETRIEVE,
+                    'where' => [
+                        ['name', Bag::COMPARATOR_EQUAL, 'test-name', Bag::CONJUNCTION_AND]
+                    ]
+                ],
+                ['command' => Bag::COMMAND_DELETE],
             ]);
 
             $this->assertEquals($expected, $actual, "failed to return correct command bag");

--- a/tests/Unit/Commands/Builders/BaseBuilder/RetrieveTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/RetrieveTest.php
@@ -17,8 +17,7 @@ class RetrieveTest extends TestSetup
     {
         $this->specify("it adds a single array of a valid constraint", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->internalWhere(['name', Bag::COMPARATOR_EQUAL, 'michael', Bag::CONJUNCTION_OR])
                 ->getBag();
 
@@ -28,7 +27,6 @@ class RetrieveTest extends TestSetup
                 'target' => Bag::ELEMENT_VERTEX,
                 'where' => [
                     ['name', Bag::COMPARATOR_EQUAL, "michael", Bag::CONJUNCTION_OR],
-
                 ]
             ]);
 
@@ -37,8 +35,7 @@ class RetrieveTest extends TestSetup
 
         $this->specify("it adds multiple valid constraint", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->internalWhere([
                     ['name', Bag::COMPARATOR_EQUAL, 'michael', Bag::CONJUNCTION_AND],
                     ['price', Bag::COMPARATOR_GT, 2, Bag::CONJUNCTION_OR]
@@ -60,8 +57,7 @@ class RetrieveTest extends TestSetup
 
         $this->specify("it throws an exception for invalid constraint: too few parameters", function () {
             $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->internalWhere(
                     ['name', Bag::COMPARATOR_EQUAL, 'michael']
                 )
@@ -70,8 +66,7 @@ class RetrieveTest extends TestSetup
 
         $this->specify("it throws an exception for invalid constraint: operator not a constant", function () {
             $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->internalWhere(
                     ['name', '=', 'michael', Bag::CONJUNCTION_AND]
                 )
@@ -80,8 +75,7 @@ class RetrieveTest extends TestSetup
 
         $this->specify("it throws an exception for invalid constraint: conjunction not a constant", function () {
             $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->internalWhere(
                     [true, Bag::COMPARATOR_EQUAL, 'michael', 'AND']
                 )
@@ -93,8 +87,7 @@ class RetrieveTest extends TestSetup
     {
         $this->specify("it adds a specified limit", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->limit(2)
                 ->getBag();
 
@@ -113,8 +106,7 @@ class RetrieveTest extends TestSetup
     {
         $this->specify("it groups results by a single field", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->groupBy('certified')
                 ->getBag();
 
@@ -130,8 +122,7 @@ class RetrieveTest extends TestSetup
 
         $this->specify("it groups results by a multiple fields array", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->groupBy(['certified', 'price'])
                 ->getBag();
 
@@ -147,8 +138,7 @@ class RetrieveTest extends TestSetup
 
         $this->specify("it groups results by a multiple fields string", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->groupBy('certified, price')
                 ->getBag();
 
@@ -167,8 +157,7 @@ class RetrieveTest extends TestSetup
     {
         $this->specify("it orders results by a field, asc by default", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->orderBy('price')
                 ->getBag();
 
@@ -184,8 +173,7 @@ class RetrieveTest extends TestSetup
 
         $this->specify("it orders results by a field, desc", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->orderBy('price', Bag::ORDER_DESC)
                 ->getBag();
 
@@ -201,8 +189,7 @@ class RetrieveTest extends TestSetup
 
         $this->specify("it orders results by a field, asc", function () {
             $actual = $this->builder
-                ->retrieve()
-                ->type(Bag::ELEMENT_VERTEX)
+                ->internalRetrieve()
                 ->orderBy('price', Bag::ORDER_ASC)
                 ->getBag();
 
@@ -215,39 +202,5 @@ class RetrieveTest extends TestSetup
 
             $this->assertEquals($expected, $actual, "failed to return correct command bag");
         });
-
-        //~ $this->specify("it orders results by multiple fields, array", function () {
-            //~ $actual = $this->builder
-                //~ ->retrieve()
-                //~ ->type(Bag::ELEMENT_VERTEX)
-                //~ ->orderBy(['price', 'owner'])
-                //~ ->getBag();
-//~
-            //~ $expected = $this->buildExpectedBag([
-                //~ 'command' => Bag::COMMAND_RETRIEVE,
-                //~ 'projections' => [],
-                //~ 'target' => Bag::ELEMENT_VERTEX,
-                //~ 'orderBy' => [['price', Bag::ORDER_ASC],['owner', Bag::ORDER_ASC]],
-            //~ ]);
-//~
-            //~ $this->assertEquals($expected, $actual, "failed to return correct command bag");
-        //~ });
-//~
-        //~ $this->specify("it orders results by multiple fields, string", function () {
-            //~ $actual = $this->builder
-                //~ ->retrieve()
-                //~ ->type(Bag::ELEMENT_VERTEX)
-                //~ ->orderBy('price, owner')
-                //~ ->getBag();
-//~
-            //~ $expected = $this->buildExpectedBag([
-                //~ 'command' => Bag::COMMAND_RETRIEVE,
-                //~ 'projections' => [],
-                //~ 'target' => Bag::ELEMENT_VERTEX,
-                //~ 'orderBy' => ['price', 'owner'],
-            //~ ]);
-//~
-            //~ $this->assertEquals($expected, $actual, "failed to return correct command bag");
-        //~ });
     }
 }

--- a/tests/Unit/Commands/Builders/BaseBuilder/UpdateTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/UpdateTest.php
@@ -14,7 +14,7 @@ class UpdateTest extends TestSetup
     {
         $this->specify("it updates a single record with a single value by ID", function () {
             $actual = $this->builder
-                ->update(['name'=> 'chris'])
+                ->internalUpdate(['name'=> 'chris'])
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
@@ -27,19 +27,24 @@ class UpdateTest extends TestSetup
 
         $this->specify("it updates a single record with a target and constraint", function () {
             $actual = $this->builder
-                ->update(['name'=> 'chris'])
+                ->internalRetrieve()
                 ->internalWhere(['username', Bag::COMPARATOR_EQUAL, 'chrismichaels84', Bag::CONJUNCTION_AND])
                 ->internalWhere([Bag::ELEMENT_LABEL, Bag::COMPARATOR_EQUAL, 'target', Bag::CONJUNCTION_AND])
-                ->type(Bag::ELEMENT_VERTEX)
                 ->limit(1)
+                ->internalUpdate(['name'=> 'chris'])
                 ->getBag();
 
-            $expected = $this->buildExpectedBag([
-                'command' => Bag::COMMAND_UPDATE,
-                'target' => Bag::ELEMENT_VERTEX,
-                'limit' => 1,
-                'where' => [['username', Bag::COMPARATOR_EQUAL, 'chrismichaels84', Bag::CONJUNCTION_AND],[Bag::ELEMENT_LABEL, Bag::COMPARATOR_EQUAL, 'target', Bag::CONJUNCTION_AND]],
-                'data' => [['name' => 'chris']]
+            $expected = $this->buildExpectedBags([
+                [
+                    'command' => Bag::COMMAND_RETRIEVE,
+                    'target' => Bag::ELEMENT_VERTEX,
+                    'limit' => 1,
+                    'where' => [['username', Bag::COMPARATOR_EQUAL, 'chrismichaels84', Bag::CONJUNCTION_AND],[Bag::ELEMENT_LABEL, Bag::COMPARATOR_EQUAL, 'target', Bag::CONJUNCTION_AND]],
+                ],
+                [
+                    'command' => Bag::COMMAND_UPDATE,
+                    'data' => [['name' => 'chris']]
+                ]
             ]);
 
             $this->assertEquals($expected, $actual, "failed to return correct command bag");
@@ -47,7 +52,7 @@ class UpdateTest extends TestSetup
 
         $this->specify("it updates multiple properties", function () {
             $actual = $this->builder
-                ->update([
+                ->internalUpdate([
                     'name' => 'chris',
                     'birthday' => 'april'
                 ])
@@ -68,9 +73,9 @@ class UpdateTest extends TestSetup
             ];
 
             $actual = $this->builder
-                ->update()
+                ->internalUpdate()
                 ->type(Bag::ELEMENT_VERTEX)
-                ->data($data) // alias withData()
+                ->data($data)
                 ->getBag();
 
             $expected = $this->buildExpectedBag([

--- a/tests/Unit/Commands/Builders/BaseBuilder/UpdateTest.php
+++ b/tests/Unit/Commands/Builders/BaseBuilder/UpdateTest.php
@@ -74,14 +74,12 @@ class UpdateTest extends TestSetup
 
             $actual = $this->builder
                 ->internalUpdate()
-                ->type(Bag::ELEMENT_VERTEX)
                 ->data($data)
                 ->getBag();
 
             $expected = $this->buildExpectedBag([
                 'command' => Bag::COMMAND_UPDATE,
                 'data' => [['name' => 'chris', 'birthday' => 'april']],
-                'target' => Bag::ELEMENT_VERTEX
             ]);
 
             $this->assertEquals($expected, $actual, "failed to return correct command bag");

--- a/tests/Unit/Commands/Builders/Builder/CreateTest.php
+++ b/tests/Unit/Commands/Builders/Builder/CreateTest.php
@@ -12,7 +12,7 @@ class CreateTest extends TestSetup
     /* Create Tests */
     public function testCreateSugars()
     {
-        $this->specify("it uses insert aliase", function () {
+        $this->specify("it uses insert aliases", function () {
             $record = [
                 'first' => 'first-value',
                 'second' => 'second-value',

--- a/tests/Unit/Commands/Builders/TestSetup.php
+++ b/tests/Unit/Commands/Builders/TestSetup.php
@@ -42,6 +42,15 @@ class TestSetup extends \PHPUnit_Framework_TestCase
         foreach ($properties as $key => $value) {
             $expected->$key = $value;
         }
+        return [$expected];
+    }
+
+    public function buildExpectedBags(array $bags)
+    {
+        $expected = [];
+        foreach ($bags as $bag) {
+            $expected[] = $this->buildExpectedBag($bag)[0];
+        }
         return $expected;
     }
 }


### PR DESCRIPTION
I finally had a couple hours, so I began work on multiple CRUD operations in a single command. The approach is a little different that we discussed, but it meets all of our goals, I think.

_This is not ready to merge!_ This is only the first draft. This PR currently breaks `Builder` and `Query` tests because I don't want to update them until this is decided upon. It does not affect any other tests and (of course) `BaseBuilder` tests have been updated and pass.

This PR begins to address the features required by #81, which is required before we dive into #19 and #53.

---

Here are some scenarios we need to cover:
     1. Create (C) two vertices and an edge between them
     2. Find (R) existing vertices and create (C) an edge between them
     3. Find (R) existing vertices and create (C) an edge between them then update that edge with properties (U)
     4. Create (C) elements and update (U) them with data.
     5. Find (R) and delete (D) elements (should already work but leaving here incase we decide to make it work in a similar fashion to the above)

A quick review of the goals from #81:
- [ ] Allow for nested-commands that are instances of `BaseBuilder` or `Bag`s 
- [ ] Allow for _declarative_ creation of vertices and edges.
- [ ] Switch to a syntax (for `BaseBuilder`) that is `$builder->select()->from()->delete()`
- [ ] Simplify `BaseBuilder` responsibility and prefix methods with `internal`
- [ ] Allow for aliasing operations via `set()` and `get()`
- [ ] Make the processors do the work

So far, this PR should cover all of the above, but only in the scope of `BaseBuilder`. I haven't touched processors, other builders, or drivers. Also, the nested queries should work because `BaseBuilder` has no awareness of them, but there are no tests for it. Tests cover everything else.
## General
- [ ] Prefixed CRUD to `internalCreate()`, `internalRetrieve()`, `internalUpdate()`, `internalDelete()`, `interalProjections()`, and `internalWhere()`
- [ ] changed `path()` and `tree()` to `setAsPath()` and `setAsTree()`
- [ ] Removed `data()` and `type()`
- [ ] left methods that aren't overridden the same (`limit()`, etc)
- [ ] I also cleaned up `Bag` a little, dropping `createCount` for instance. I think we can drop `target` as well. 
## Multiple Operations

I did end up taking a different approach that we discussed. Instead of having `Bag::$create` etc, I opted for `BaseBuilder` creating an _array_ of CommandBags. Ordering is strictly kept and a new Bag is only added to the stack when one of the CRUD methods is called. I did this because it seemed simpler, more flexible, and more intuitive in controlling what _order_ the operations are executed in.

**A breakdown of what's going on** from the scenarios above:

---
## 1

``` php
(new BaseBuilder())->internalCreate([   
   [TYPE => VERTEX, LABEL => 'person', "name" => 'what'],
   [TYPE => VERTEX, LABEL => 'person', "name" => 'ever'],
   [
      TYPE => EDGE,
      LABEL => 'friend',
      INV => (new BaseBuilder())->internalCreate([[TYPE => VERTEX, LABEL => 'person', "name" => 'michael']]),
      OUTV => (new BaseBuilder())->internalCreate([[TYPE => VERTEX, LABEL => 'person', "name" => 'dylan']])
   ]
]);
```
## 2

``` php
(new BaseBuilder())->internalCreate([
   [
      TYPE => EDGE,
      LABEL => 'friend',
      INV => (new BaseBuilder())->internalRetrieve()->internalWhere(["name", EQUALS, "michael", AND]),
      OUTV =>  (new BaseBuilder())->internalRetrieve()->internalWhere(["name", EQUALS, "dylan", AND])
   ]
]);
```
## 3

``` php
(new BaseBuilder())->internalCreate([
   [
      TYPE => EDGE,
      LABEL => 'friend',
      INV => (new BaseBuilder())->internalRetrieve()->internalWhere(["name", EQUALS, "michael", AND]),
      OUTV =>  (new BaseBuilder())->internalRetrieve()->internalWhere(["name", EQUALS, "dylan", AND])
   ]
])
->update(['weight' => 15]);
```

In this specific case, the processor would have to know to look at the previous operation in the batch to query which edges to update. _I don't like this_

A better way:

``` php
(new BaseBuilder())->internalCreate([
   [
      TYPE => EDGE,
      LABEL => 'friend',
      INV => (new BaseBuilder())->internalRetrieve()->internalWhere(["name", EQUALS, "michael", AND]),
      OUTV =>  (new BaseBuilder())->internalRetrieve()->internalWhere(["name", EQUALS, "dylan", AND])
   ],
   'weight' => 1.5
])
```
## 4

Same as above
## 5

``` php
$builder->internalRetrieve()->internalWhere()->delete();
```

In this case, again, the processor would have to know to use the previous operation to find which to delete. At least, this is what Orient would translate to

```
DELETE VERTEX (SELECT FROM V WHERE x = y)
```

or

```
begin batch
LET a = SELECT FROM V WHERE x = y
LET b = DELETE VERTEX $a
commit
```
## Setting aliases

``` php
$builder->internalCreate([
   TYPE => VERTEX,
   LABEL => 'person'
   name => 'michael'
])->set('michael');

$builder->internalCreate([
   TYPE => VERTEX,
   LABEL => 'person'
   name => 'dylan'
])->set('dylan');

$builder->internalCreate([
   TYPE => EDGE,
   LABEL => 'friend'
   weight=> 3
   INV => $builder->get('michael')
   OUTV => $builder->get('dylan')
]);
```

---

This is all still a rough draft, but let me know what you think. I will probably comb through this again tomorrow to see if I can clean it up a bit and make sure it all works as expected for edge cases.
