### PR TITLE
fix all dependencies on semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Changelog
 All Notable changes to `Spider` will be documented in this file
 
-## v0.3 - NEXT
+## v0.3.2 - 10-8-2015
+- Fixes dependency versions in composer.json
+- Fixes bug #91: Gremlin-PHP updated version was breaking change
+
+## v0.3.1 - 9-1-2015
+- Fixes bug #63: Set ordering in tests for Neo4j
+- Cleans up scrutinizer
+
+## v0.3.0 - 8-22-2015
 - Basic Query Builder (without traversals)
   - Where filters
   - limit and group

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,14 @@
   "require": {
     "php": ">=5.4.0",
     "michaels/data-manager": "0.8.*",
-    "ostico/phporient": "1.2.*",
-    "brightzone/gremlin-php": "1.0",
-    "everyman/neo4jphp": "dev-master"
+    "ostico/phporient": "1.*",
+    "brightzone/gremlin-php": "1.0.*",
+    "everyman/neo4jphp": "0.1.*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",
-    "satooshi/php-coveralls": "dev-master",
-    "codeception/specify": "*"
+    "satooshi/php-coveralls": "0.6.*",
+    "codeception/specify": "0.4.*"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "michaels/data-manager": "0.8.*",
     "ostico/phporient": "1.*",
     "brightzone/gremlin-php": "1.0.*",
-    "everyman/neo4jphp": "0.1.*"
+    "everyman/neo4jphp": "dev-master"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",


### PR DESCRIPTION
This will be 0.3.2 -- just a pr to make sure tests pass.

After merged, I will merge this into develop.

This keeps php 5.4. I'll commit to `develop` for 5.6 and then we can merge the changes down from there.
