### PR TITLE
Adds a vagrant box for easier sharable development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All Notable changes to `Spider` will be documented in this file
 - Query api uses verb-based dispatch methods (getAll(), getOne(), etc)
 - Refactor: OrientDB uses SqlBatch for commands consistently
 - Simplified Drivers by replacing read/writeCommand() with single executeCommand() and runCommand()
+- Adds a Vagrant box for easier development environment.
 
 ## v0.3.2 - 10-8-2015
 - Fixes dependency versions in composer.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/spider/
 
 - **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
 
-## Running Tests
+## Running Tests and Virtual Environments
 See documentation.
 
 ## Branches

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,32 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "scotch/box"
+
+  # For internet connectivity
+  config.vm.provider "virtualbox" do |v|
+      v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+  end
+
+  # Not sure this is needed for spider
+  config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.hostname = "scotchbox"
+
+  # Install test databases when building machine
+  config.vm.provision :shell, path: "./vagrant/bootstrap.sh"
+
+  # Start databases every time
+  config.vm.provision :shell, path: "./vagrant/startup.sh", run: "always"
+end

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,16 +28,46 @@ Be sure to fetch often so you keep your sources up-to-date!
 
 ## Test Databases
 In order to really test Spider, you need to install the test databases for the different drivers.
-At the moment, there are three drivers. These are instructions for installing each db so all tests will pass.
+At the moment, there are three drivers. 
 
-### Gremlin-Server
-#### Download
+You have two options in setting up your development environment. Instructions are provided for installing each database individually, or a [Vagrant](http://vagrantup.com/) box is provided to use a pre-configured virtual machine.
+
+### Vagrant
+It is easy to setup a development environment to test Spider by using [Vagrant](http://vagrantup.com/), which creates a virtual machine. This isolates things like the databases and ensure that the correct php configuration is set. Simply turn on the Vagrant box when developing and turn it off when you are done.
+
+To use the vagrant box, you must have 
+[Vagrant](https://www.vagrantup.com/downloads.html) and 
+[Virtual box](https://www.virtualbox.org/wiki/Downloads) installed. 
+This couldn't be simpler. Both are free. Directions on each website.
+
+Once these are installed simply use terminal or command prompt to `cd` into the directory and run `vagrant up`.
+The first time you run it, it may take a while to download everything (several Gigabytes). 
+From there, you can `vagrant ssh` into the virtual machine and `cd /vagrant`. Then run `phpunit` to see the magic happen.
+
+Please read up on Vagrant. Its super simple and powerful.
+
+Once you are finished developing, you have 3 options to turn off vagrant:
+`vagrant suspend` will keep the box as it is, but dump it all to the hard disk. Takes up some Hard drive space, but no extra ram. Fastest when turning it back on.
+
+`vagrant halt` will totally shutdown the box.
+
+With the above two options, you will NOT have to re-download anything next time, but it does eat up a few gigs of hard drive space.
+
+`vagrant destroy` totally removes the box. You will have to re-download some things next time. All is automatic.
+
+When ready to begin again, `vagrant up`.
+
+### Install locally
+You may also setup the databases locally. These are instructions for installing each db so all tests will pass.
+
+#### Gremlin-Server
+##### Download
 - [Gremlin-server](https://www.apache.org/dist/incubator/tinkerpop/3.0.0-incubating/apache-gremlin-server-3.0.0-incubating-bin.zip)
 - [gremlin-server-php.yaml](https://raw.githubusercontent.com/PommeVerte/gremlin-php/master/src/tests/gremlin-server-php.yaml)
 - [gremlin-php-script.groovy](https://raw.githubusercontent.com/PommeVerte/gremlin-php/master/src/tests/gremlin-php-script.groovy)
 - [neo4j-empty.properties](https://raw.githubusercontent.com/PommeVerte/gremlin-php/master/src/tests/neo4j-empty.properties)
 
-#### Installation
+##### Installation
 Extract Gremlin-server and go into the created folder.
 
 Neo4J is required for the full test suit (it serves as the transaction enabled graph). It is not bundled with gremlin-server by default so you will need to manually install it with:
@@ -65,20 +95,20 @@ and use .bat files:
 bin\gremlin-server.bat conf\gremlin-server-php.yaml
 ```
 
-### Neo4J
-#### Download
+#### Neo4J
+##### Download
 - [Neo4J Server](http://neo4j.com/download/) (Community version is tested)
 
-#### Installation
+##### Installation
 Once the server is up and running, connect to [http://localhost:7474/browser](http://localhost:7474/browser) 
 - Change the username:password from `neo4j:neo4j` to `neo4j:j4oen`
 - It is recommended to create a 'testing' graph or similar, as the test suite will wipe all existing data before and after each test.
 
-### OrientDB
-#### Download
+#### OrientDB
+##### Download
 - [OrientDB Community](http://orientdb.com/download/) (Community version is tested)
 
-#### Installation
+##### Installation
 Simply extract the directory and place it anywhere you like.
 
 That's really it. The server can be accessed by connecting to : [http://localhost:2480/](http://localhost:2480/).

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+echo "------------ PROVISIONING SYSTEM FROM BOOTSTRAP ------------"
+
+# Set variables
+export NEO4J_VERSION="2.2.4"
+export GREMLINSERVER_VERSION="3.0.0"
+export ORIENT_VERSION="2.1.0"
+
+export INSTALL_DIR="/home/vagrant"
+export VAGRANT_DIR="/vagrant"
+export BOOTSTRAP_DIR="$VAGRANT_DIR/vagrant"
+
+
+### INSTALL jdk8
+## Get dependencies (for adding repos)
+sudo apt-get install -y python-software-properties
+sudo add-apt-repository -y ppa:webupd8team/java
+sudo apt-get update
+
+## install oracle jdk 8
+# no interaction
+echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections
+
+# run installer
+sudo apt-get install -y oracle-java8-installer
+sudo update-alternatives --auto java
+sudo update-alternatives --auto javac
+
+## add to environment
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+export JRE_HOME=/usr/lib/jvm/java-8-oracle
+
+
+### install gremlin-server
+export GREMLIN_DIR="apache-gremlin-server-$GREMLINSERVER_VERSION-incubating"
+
+# download and unzip
+wget --no-check-certificate -O $INSTALL_DIR/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating-bin.zip https://www.apache.org/dist/incubator/tinkerpop/$GREMLINSERVER_VERSION-incubating/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating-bin.zip
+unzip $INSTALL_DIR/apache-gremlin-server-$GREMLINSERVER_VERSION-incubating-bin.zip -d $INSTALL_DIR/
+
+# get gremlin-server configuration files
+cp $BOOTSTRAP_DIR/gremlin-spider-script.groovy $INSTALL_DIR/$GREMLIN_DIR/scripts/
+cp $BOOTSTRAP_DIR/gremlin-server-spider.yaml $INSTALL_DIR/$GREMLIN_DIR/conf/
+
+# get neo4j dependencies
+#$INSTALL_DIR/$GREMLIN_DIR/bin/gremlin-server.sh -i org.apache.tinkerpop neo4j-gremlin $GREMLINSERVER_VERSION-incubating
+
+# get neo4j dependencies
+cd $INSTALL_DIR/$GREMLIN_DIR
+bin/gremlin-server.sh -i org.apache.tinkerpop neo4j-gremlin $GREMLINSERVER_VERSION-incubating
+sleep 30
+cd $VAGRANT_DIR
+
+### install neo4j
+# install Neo4j locally:
+wget -O $INSTALL_DIR/neo4j-community-$NEO4J_VERSION-unix.tar.gz dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz
+tar -xzf $INSTALL_DIR/neo4j-community-$NEO4J_VERSION-unix.tar.gz -C $INSTALL_DIR/
+
+### install orient
+# Download orient
+wget -O $INSTALL_DIR/orientdb-community-$ORIENT_VERSION.tar.gz wget http://www.orientechnologies.com/download.php?file=orientdb-community-$ORIENT_VERSION.tar.gz
+tar -xzf $INSTALL_DIR/orientdb-community-$ORIENT_VERSION.tar.gz -C $INSTALL_DIR/
+
+# update config with correct user/password
+sed -i '/<users>/a <user name="root" password="root" resources="*"><\/user>' $INSTALL_DIR/orientdb-community-$ORIENT_VERSION/config/orientdb-server-config.xml
+
+
+### install X-debug for code coverage
+sudo apt-get install php5-xdebug
+
+echo "------------ END: PROVISIONING SYSTEM FROM BOOTSTRAP ------------"

--- a/vagrant/gremlin-server-spider.yaml
+++ b/vagrant/gremlin-server-spider.yaml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+host: localhost
+port: 8182
+threadPoolWorker: 1
+gremlinPool: 8
+scriptEvaluationTimeout: 30000
+serializedResponseTimeout: 30000
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphs: {
+  graph: conf/tinkergraph-empty.properties ,
+  graphT: conf/neo4j-empty.properties
+}
+plugins:
+  - tinkerpop.neo4j
+  - tinkerpop.tinkergraph
+scriptEngines: {
+  gremlin-groovy: {
+    imports: [java.lang.Math],
+    staticImports: [java.lang.Math.PI],
+    scripts: [scripts/gremlin-spider-script.groovy]},
+  nashorn: {
+      imports: [java.lang.Math],
+      staticImports: [java.lang.Math.PI]}}
+serializers:
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0 }                                             # application/vnd.gremlin-v1.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }                                  # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }                                         # application/json
+processors:
+  - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
+metrics: {
+  consoleReporter: {enabled: true, interval: 180000},
+  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  jmxReporter: {enabled: true},
+  slf4jReporter: {enabled: true, interval: 180000},
+  gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
+  graphiteReporter: {enabled: false, interval: 180000}}
+threadPoolBoss: 1
+maxInitialLineLength: 4096
+maxHeaderSize: 8192
+maxChunkSize: 8192
+maxContentLength: 65536
+maxAccumulationBufferComponents: 1024
+resultIterationBatchSize: 64
+writeBufferHighWaterMark: 32768
+writeBufferHighWaterMark: 65536
+ssl: {
+  enabled: false}

--- a/vagrant/gremlin-spider-script.groovy
+++ b/vagrant/gremlin-spider-script.groovy
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// defines a sample LifeCycleHook that prints some output to the Gremlin Server console.
+// it is important that the hook be assigned to a variable (in this case "hook").
+// the exact name of this variable is unimportant.
+hook = [
+  onStartUp: { ctx ->
+    ctx.logger.info("Executed once at startup of Gremlin Server.");
+  },
+  onShutDown: { ctx ->
+    ctx.logger.info("Executed once at shutdown of Gremlin Server.")
+  }
+] as LifeCycleHook
+
+// define the default TraversalSource to bind queries to.
+t = graphT.traversal()
+g = graph.traversal()
+
+// An example of an initialization script that can be configured to run in Gremlin Server.
+// Functions defined here will go into global cache and will not be removed from there
+// unless there is a reset of the ScriptEngine.
+//def addItUp(x, y) { x + y }

--- a/vagrant/startup.sh
+++ b/vagrant/startup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+echo "------------ RUNNING STARTUP COMMANDS ------------"
+
+### Set variables
+export NEO4J_VERSION="2.2.4"
+export GREMLINSERVER_VERSION="3.0.0"
+export ORIENT_VERSION="2.1.0"
+
+export INSTALL_DIR="/home/vagrant"
+export VAGRANT_DIR="/vagrant"
+export BOOTSTRAP_DIR="$VAGRANT_DIR/vagrant"
+
+export GREMLIN_DIR="apache-gremlin-server-$GREMLINSERVER_VERSION-incubating"
+
+## start gremlin-server
+cd $INSTALL_DIR/$GREMLIN_DIR
+sudo bin/gremlin-server.sh conf/gremlin-server-spider.yaml > /dev/null 2>&1 &
+cd $VAGRANT_DIR
+sleep 30
+
+## start neo4j
+sudo $INSTALL_DIR/neo4j-community-$NEO4J_VERSION/bin/neo4j start
+sleep 15
+
+# changing password:
+sudo curl -vX POST http://neo4j:neo4j@localhost:7474/user/neo4j/password -d"password=j4oen"
+
+## start orient
+sudo nohup $INSTALL_DIR/orientdb-community-$ORIENT_VERSION/bin/server.sh > $INSTALL_DIR/orientdb-community-$ORIENT_VERSION/log/server.out&
+sleep 15
+
+echo "------------ END: RUNNING STARTUP COMMANDS ------------"
+
+#if [ -f /home/vagrant/gremlin-server-spider.yaml ];
+#then
+#   echo "yes."
+#   touch /home/vagrant/still.exists.txt
+#else
+#   echo "no."
+#   touch /home/vagrant/doesnotexist.txt
+#fi


### PR DESCRIPTION
This adds a [Vagrant](http://vagrantup.com/) box to easily get a virtual environment setup with all the test databases. See docs/contributing.md for more details.

There is probably a way to share the CI and Vagrant folders, but I didn't look at it too closely.
